### PR TITLE
feat/#242: 서브도메인 제거 임시 라우트 변경

### DIFF
--- a/components/blog/ui/ArticleListWithThumbnail.tsx
+++ b/components/blog/ui/ArticleListWithThumbnail.tsx
@@ -59,7 +59,7 @@ const ArticleListWithThumbnail = (props: ArticleListWithThumbnailProps) => {
       <>
         <ContentInfoContainer>
           {contentListData && contentListData.thumbnail && (
-            <Link href={`/content/article/${articleUrl}/${IndivContentId}`}>
+            <Link href={`/${team}/content/article/${articleUrl}/${IndivContentId}`}>
               <Image width="720" height="405" src={contentListData.thumbnail} alt="blog thumbnail" />
             </Link>
           )}

--- a/components/blog/ui/CategoryBtnBar.tsx
+++ b/components/blog/ui/CategoryBtnBar.tsx
@@ -12,7 +12,7 @@ interface CategoryBtnBarProps {
   LiteralList: string[];
 }
 const CategoryBtnBar = (props: CategoryBtnBarProps) => {
-  const { category } = useParams();
+  const { team, category } = useParams();
   const { LiteralList } = props;
   const SELECTED = useGetCategory();
   const MOBILE = useMediaQuery({
@@ -23,7 +23,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
     if (MOBILE)
       return (
         <MobileCategoryBtn
-          href={`/home/${eachCategory}`}
+          href={`/${team}/home/${eachCategory}`}
           key={eachCategory}
           type="button"
           className={eachCategory === decodeURI(category) ? 'selected' : ''}>
@@ -33,7 +33,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
     else
       return (
         <CategoryBtn
-          href={`/home/${eachCategory}`}
+          href={`/${team}/home/${eachCategory}`}
           key={eachCategory}
           type="button"
           className={eachCategory === decodeURI(category) ? 'selected' : ''}>
@@ -45,7 +45,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
   if (MOBILE)
     return (
       <CategoryBtnBarContainer className="mobile">
-        <MobileCategoryBtn href={`/home`} type="button" className={SELECTED === 'home' ? 'selected' : ''}>
+        <MobileCategoryBtn href={`/${team}/home`} type="button" className={SELECTED === 'home' ? 'selected' : ''}>
           전체
         </MobileCategoryBtn>
         {CATEGORY_LIST}
@@ -54,7 +54,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
   else
     return (
       <CategoryBtnBarContainer>
-        <CategoryBtn href={`/home`} type="button" className={SELECTED === 'home' ? 'selected' : ''}>
+        <CategoryBtn href={`/${team}/home`} type="button" className={SELECTED === 'home' ? 'selected' : ''}>
           전체
         </CategoryBtn>
         {CATEGORY_LIST}
@@ -72,6 +72,7 @@ const CategoryBtnBarContainer = styled.div`
 
   padding: 7.2rem 0 4.8rem;
   width: 72rem;
+
   &.mobile {
     padding: 2.8rem 2.4rem 2.2rem;
     width: 100%;

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 
 import useGetCategory from '@/hooks/useGetCategory';
@@ -19,9 +20,10 @@ const Article = (props: ArticleProps) => {
   } = props;
 
   const selectedCategory = useGetCategory();
+  const { team } = useParams();
 
   return (
-    <ArticleContainer href={`/content/article/${articleUrl}/${id}`} className={noHover ? '' : 'hover'}>
+    <ArticleContainer href={`/${team}/content/article/${articleUrl}/${id}`} className={noHover ? '' : 'hover'}>
       <ArticleInfo>
         <EditorInputTitle className="title">{title}</EditorInputTitle>
         <ArticleDescription className="description">{description}</ArticleDescription>

--- a/components/common/BlogNav.tsx
+++ b/components/common/BlogNav.tsx
@@ -27,7 +27,7 @@ const BlogNav = () => {
       {navList &&
         navList.map(({ navUrl, name, isPage, id }) => (
           <PageBtn key={navUrl}>
-            <Link href={isPage ? `/content/page/${navUrl}/${id}` : `${navUrl}`}>{name}</Link>
+            <Link href={isPage ? `/${team}/content/page/${navUrl}/${id}` : `${navUrl}`}>{name}</Link>
           </PageBtn>
         ))}
       {/* 밑의 버튼은 구독자 기능 생성 후 다시 넣어줄 예정 */}

--- a/components/common/ContentInfo.tsx
+++ b/components/common/ContentInfo.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useMediaQuery } from 'react-responsive';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 
 import useGetIfContentPage from '@/hooks/useGetIfContentPage';
@@ -33,6 +34,7 @@ const ContentInfo = (props: ContentInfoProps) => {
   });
 
   const { contentInfoData, IndivContentId, articleUrl } = props;
+  const { team } = useParams();
 
   const ifContent = useGetIfContentPage();
   const ifPage = useGetIfPage();
@@ -54,7 +56,7 @@ const ContentInfo = (props: ContentInfoProps) => {
           </ContentDetailBox>
         ) : (
           <ContentDetailBox>
-            <Link href={`/content/article/${articleUrl}/${IndivContentId}`}>
+            <Link href={`/${team}/content/article/${articleUrl}/${IndivContentId}`}>
               <TitleBox className="mobile">{title}</TitleBox>
               {description && <DescriptionBox className="mobile">{description}</DescriptionBox>}
             </Link>
@@ -62,7 +64,7 @@ const ContentInfo = (props: ContentInfoProps) => {
         )}
         {name && (
           <WriterBox>
-            <WriterInfo href={`/author/${id}`}>
+            <WriterInfo href={`/${team}/author/${id}`}>
               {thumbnail ? <WriterProfilePic src={thumbnail} alt="writer profile pic" /> : <NoUserProfileIcon />}
               <WriterDetailBox>
                 <WriterNameBox>
@@ -86,7 +88,7 @@ const ContentInfo = (props: ContentInfoProps) => {
           </ContentDetailBox>
         ) : (
           <ContentDetailBox>
-            <Link href={`/content/article/${articleUrl}/${IndivContentId}`}>
+            <Link href={`/${team}/content/article/${articleUrl}/${IndivContentId}`}>
               <TitleBox>{title}</TitleBox>
               {description && <DescriptionBox>{description}</DescriptionBox>}
             </Link>
@@ -94,7 +96,7 @@ const ContentInfo = (props: ContentInfoProps) => {
         )}
         {name && (
           <WriterBox>
-            <WriterInfo href={`/author/${id}`}>
+            <WriterInfo href={`/${team}/author/${id}`}>
               {thumbnail ? <WriterProfilePic src={thumbnail} alt="writer profile pic" /> : <NoUserProfileIcon />}
               <WriterDetailBox>
                 <WriterNameBox>

--- a/components/common/HeaderLogo.tsx
+++ b/components/common/HeaderLogo.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 interface LogoProp {
   logo: string | null;
@@ -10,9 +11,10 @@ interface LogoProp {
 
 const HeaderLogo = (prop: LogoProp) => {
   const { logo, blogName } = prop;
+  const { team } = useParams();
 
   return (
-    <Link href={`/home`}>
+    <Link href={`/${team}/home`}>
       {logo ? (
         <>
           <img src={logo} alt="team logo icon" height={24} />

--- a/components/common/MobileArticle.tsx
+++ b/components/common/MobileArticle.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 
 import useGetCategory from '@/hooks/useGetCategory';
@@ -17,9 +18,10 @@ const MobileArticle = (props: ArticleProps) => {
   } = props;
 
   const selectedCategory = useGetCategory();
+  const { team } = useParams();
 
   return (
-    <ArticleContainer href={`/content/article/${articleUrl}/${id}`}>
+    <ArticleContainer href={`/${team}/content/article/${articleUrl}/${id}`}>
       {thumbnail && <ArticleThumbnail src={thumbnail} alt="Article Thumbnail" />}
       <ArticleInfo>
         <EditorInputTitle>{title}</EditorInputTitle>

--- a/components/common/SideBarNav.tsx
+++ b/components/common/SideBarNav.tsx
@@ -25,7 +25,7 @@ const SideBarNav = () => {
       {navList &&
         navList.map(({ navUrl, name, isPage, id }) => (
           <NavBtn key={navUrl} type="button">
-            <NavLink href={isPage ? `/content/page/${navUrl}/${id}` : `${navUrl}`}>{name}</NavLink>
+            <NavLink href={isPage ? `/${team}/content/page/${navUrl}/${id}` : `${navUrl}`}>{name}</NavLink>
           </NavBtn>
         ))}
     </BlogNavContainer>


### PR DESCRIPTION
## 🔥 Related Issues
- close #242 

## 💙 작업 내용
- [x] 서브도메인을 다시 사용하기 전까지 임시로 라우트를 변경해두었습니다

## ✅ PR Point
- 서브도메인이 적용되었던 페이지들 중 링크로 이동하는 href에 모두 블로그 이름을 다시 넣어주었습니다