### PR TITLE
Feat/#256/dashboard metadata

### DIFF
--- a/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
+++ b/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
@@ -12,6 +12,10 @@ import BlogInfoDeleteButton from './BlogDeleteButton';
 import BlogDescribeText from './BlogDescribeText';
 import BlogLogoImage from './BlogLogoImage';
 import BlogMainImage from './BlogMainImge';
+import BlogMetaDataDesciption from './BlogMetaDataDescription';
+import BlogMetaDataDescription from './BlogMetaDataDescription';
+import BlogMetaDataImage from './BlogMetaDataImage';
+import BlogMetaDataTitle from './BlogMetaDataTitle';
 import BlogName from './BlogName';
 import BlogSubHeading from './BlogSubHeading';
 import BlogUrl from './BlogUrl';
@@ -162,6 +166,9 @@ const BlogConfigTemplate = () => {
           mainHeaderText={'메타데이터 설정'}
           subHeaderText={'카카오톡, 페이스북 등으로 블로그의 링크를 공유할 때 뜨는 제목, 설명, 이미지 정보입니다'}
         />
+        <BlogMetaDataImage />
+        <BlogMetaDataTitle />
+        <BlogMetaDataDescription />
         <BlogInfoDeleteButton />
         <BlogSaveButton type="button" disabled={blogConfig.blogName === ''} onClick={postBlogConfig}>
           저장하기

--- a/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
+++ b/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
@@ -13,6 +13,7 @@ import BlogDescribeText from './BlogDescribeText';
 import BlogLogoImage from './BlogLogoImage';
 import BlogMainImage from './BlogMainImge';
 import BlogName from './BlogName';
+import BlogSubHeading from './BlogSubHeading';
 import BlogUrl from './BlogUrl';
 
 interface BlogConfigProps {
@@ -119,6 +120,7 @@ const BlogConfigTemplate = () => {
         }}
       />
       <BlogBasicInfoContainer>
+        <BlogSubHeading mainHeaderText={'기본설정'} />
         <BlogUrl blogUrl={res.data.url} />
         <BlogName
           blogName={blogConfig.blogName}
@@ -155,6 +157,10 @@ const BlogConfigTemplate = () => {
               blogDescribeText: v,
             }))
           }
+        />
+        <BlogSubHeading
+          mainHeaderText={'메타데이터 설정'}
+          subHeaderText={'카카오톡, 페이스북 등으로 블로그의 링크를 공유할 때 뜨는 제목, 설명, 이미지 정보입니다'}
         />
         <BlogInfoDeleteButton />
         <BlogSaveButton type="button" disabled={blogConfig.blogName === ''} onClick={postBlogConfig}>

--- a/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
+++ b/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
@@ -15,6 +15,7 @@ import BlogMainImage from './BlogMainImge';
 import BlogMetaDataDesciption from './BlogMetaDataDescription';
 import BlogMetaDataDescription from './BlogMetaDataDescription';
 import BlogMetaDataImage from './BlogMetaDataImage';
+import MetaDataPreview from './BlogMetaDataPreview';
 import BlogMetaDataTitle from './BlogMetaDataTitle';
 import BlogName from './BlogName';
 import BlogSubHeading from './BlogSubHeading';
@@ -169,6 +170,7 @@ const BlogConfigTemplate = () => {
         <BlogMetaDataImage />
         <BlogMetaDataTitle />
         <BlogMetaDataDescription />
+        <MetaDataPreview />
         <BlogInfoDeleteButton />
         <BlogSaveButton type="button" disabled={blogConfig.blogName === ''} onClick={postBlogConfig}>
           저장하기

--- a/components/dashboard/blogBasicInfo/BlogDescribeText.tsx
+++ b/components/dashboard/blogBasicInfo/BlogDescribeText.tsx
@@ -48,7 +48,7 @@ const BlogDescribeTextarea = styled.textarea<{ $isScrollable: boolean }>`
   border-radius: 0.8rem;
   padding: 1rem 1.2rem 5rem;
   width: 64.5rem;
-  height: 7.9rem;
+  height: 8.6rem;
   overflow-y: ${({ $isScrollable }) => ($isScrollable ? 'auto' : 'hidden')};
   resize: none;
   color: ${({ theme }) => theme.colors.grey_900};

--- a/components/dashboard/blogBasicInfo/BlogMainImge.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMainImge.tsx
@@ -86,7 +86,6 @@ const DeleteImageButton = styled.button`
 const UploadText = styled.p`
   ${({ theme }) => theme.fonts.Body2_Semibold};
   margin-left: 0.6rem;
-  width: 14.8rem;
   color: ${({ theme }) => theme.colors.grey_700};
 `;
 

--- a/components/dashboard/blogBasicInfo/BlogMetaDataDescription.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataDescription.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { ChangeEvent } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import { blogMetaDataState } from '../state/blogMetaData';
+
+const BlogMetaDataDescription = () => {
+  const [{ description }, setBlogMetaData] = useRecoilState(blogMetaDataState);
+
+  const handleOnMetaDescriptionChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.currentTarget;
+    setBlogMetaData((prev) => ({ ...prev, description: value }));
+  };
+
+  return (
+    <BlogMetaDataDescriptionContainer>
+      <MetaDataDescriptionTitle>메타데이터 설명</MetaDataDescriptionTitle>
+      <MetaDataDescriptionTextarea
+        value={description}
+        placeholder="메타데이터 설명을 입력하세요"
+        onChange={handleOnMetaDescriptionChange}
+      />
+    </BlogMetaDataDescriptionContainer>
+  );
+};
+
+export default BlogMetaDataDescription;
+
+const MetaDataDescriptionTextarea = styled.textarea`
+  ${({ theme }) => theme.fonts.Body2_Regular};
+  gap: 1rem;
+  align-items: flex-start;
+  border: 1px solid ${({ theme }) => theme.colors.grey_400};
+  border-radius: 0.8rem;
+  padding: 1rem 1.2rem;
+  width: 64.5rem;
+  height: 8.6rem;
+  resize: none;
+  color: ${({ theme }) => theme.colors.grey_900};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.grey_600};
+  }
+  &:focus {
+    outline: none;
+    border: 1px solid ${({ theme }) => theme.colors.grey_700};
+  }
+`;
+
+const MetaDataDescriptionTitle = styled.span`
+  ${({ theme }) => theme.fonts.Body2_Semibold};
+  margin: 0.5rem 6.56rem 0.8rem 0;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.colors.grey_950};
+`;
+
+const BlogMetaDataDescriptionContainer = styled.div`
+  display: flex;
+  margin-top: 3.2rem;
+`;

--- a/components/dashboard/blogBasicInfo/BlogMetaDataImage.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataImage.tsx
@@ -1,0 +1,1 @@
+'use client';

--- a/components/dashboard/blogBasicInfo/BlogMetaDataImage.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataImage.tsx
@@ -1,1 +1,111 @@
 'use client';
+import React, { ChangeEvent } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import { CloseIcon, UploadIcon } from '@/public/icons';
+import { getImageMultipartData } from '@/utils/getImageMultipartData';
+
+import { blogMetaDataState } from '../state/blogMetaData';
+
+const BlogMetaDataImage = () => {
+  const [{ image }, setBlogMetaData] = useRecoilState(blogMetaDataState);
+
+  const handleOnMetaImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.currentTarget;
+
+    if (files) {
+      const blogMetaImage = await getImageMultipartData(files[0]);
+      setBlogMetaData((prev) => ({ ...prev, image: blogMetaImage }));
+    }
+  };
+
+  return (
+    <BlogMetaImageContainer>
+      <ImageGuideContainer>
+        <MetaDataHeader>메타데이터 이미지</MetaDataHeader>
+        <ImageGuideContent>
+          이미지 권장 크기는 <p>500*500 입니다</p>
+        </ImageGuideContent>
+      </ImageGuideContainer>
+      {image ? (
+        // 메타 이미지 있으면 삭제할 수 있게 함
+        <ImageLabel>
+          <input type="file" onChange={handleOnMetaImageChange} />
+          <ImageUpload src={image} alt="meta data image" />
+        </ImageLabel>
+      ) : (
+        // 메타 이미지 없을때 초기상황
+        <ImageLabel>
+          <input type="file" onChange={handleOnMetaImageChange} />
+          <BlogMetaDataImageUpload>
+            <UploadIcon />
+            <UploadText>업로드하기</UploadText>
+          </BlogMetaDataImageUpload>
+        </ImageLabel>
+      )}
+    </BlogMetaImageContainer>
+  );
+};
+
+export default BlogMetaDataImage;
+
+const ImageUpload = styled.img`
+  margin-left: 1.8rem;
+  border-radius: 0.8rem;
+  width: 64.5rem;
+  height: 22.4rem;
+  object-fit: cover;
+`;
+
+const UploadText = styled.p`
+  ${({ theme }) => theme.fonts.Body2_Semibold};
+  margin-left: 0.6rem;
+  color: ${({ theme }) => theme.colors.grey_700};
+`;
+
+const BlogMetaDataImageUpload = styled.div`
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  margin-left: 1.8rem;
+  border-radius: 0.8rem;
+  background-color: ${({ theme }) => theme.colors.grey_200};
+  cursor: pointer;
+  width: 64.5rem;
+  height: 22.4rem;
+`;
+
+const ImageLabel = styled.label`
+  cursor: pointer;
+  & > input {
+    display: none;
+  }
+`;
+
+const ImageGuideContent = styled.p`
+  margin-top: 0.4rem;
+  width: 14.8rem;
+  ${({ theme }) => theme.fonts.Caption};
+  color: ${({ theme }) => theme.colors.grey_700};
+  p {
+    margin-top: 0.4rem;
+  }
+`;
+
+const MetaDataHeader = styled.p`
+  ${({ theme }) => theme.fonts.Body2_Semibold};
+  color: ${({ theme }) => theme.colors.grey_950};
+`;
+
+const BlogMetaImageContainer = styled.div`
+  display: flex;
+  margin-top: 3.2rem;
+`;
+
+const ImageGuideContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.8rem;
+`;

--- a/components/dashboard/blogBasicInfo/BlogMetaDataPreview.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataPreview.tsx
@@ -30,8 +30,8 @@ const MetaDataPreview = () => {
 export default MetaDataPreview;
 
 const PreviewHeader = styled.h1`
-  color: ${({ theme }) => theme.colors.dimmed};
   ${({ theme }) => theme.mobileFonts.Button};
+  color: ${({ theme }) => theme.colors.dimmed};
 `;
 
 const MetaDataPreviewContainer = styled.div`
@@ -57,8 +57,8 @@ const PreviewBlogUrl = styled.p`
 `;
 
 const PreviewDescription = styled.p`
-  margin-top: 1.5rem;
   ${({ theme }) => theme.fonts.Body2_Regular};
+  margin-top: 1.5rem;
   width: 22.8rem;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/components/dashboard/blogBasicInfo/BlogMetaDataPreview.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataPreview.tsx
@@ -1,0 +1,85 @@
+'use client';
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import { blogMetaDataState } from '../state/blogMetaData';
+
+const MetaDataPreview = () => {
+  const [blogMetaData, setBlogMetaData] = useRecoilState(blogMetaDataState);
+
+  const { image, title, description } = blogMetaData;
+
+  return (
+    <MetaDataPreviewContainer>
+      <PreviewHeader>미리보기</PreviewHeader>
+      <MetaDataPreviewBoxContainer>
+        {image ? <PreviewImage src={image} alt="meta data image" /> : <NonePreviewImage></NonePreviewImage>}
+        {/* 14.2 */}
+        <PreviewBottomContainer>
+          <PreviewTitle>{title}</PreviewTitle>
+          <PreviewDescription>{description}</PreviewDescription>
+          {/* url 자리임 -> 데이터 받아서 교체*/}
+          <PreviewBlogUrl>Parmspring.com</PreviewBlogUrl>
+        </PreviewBottomContainer>
+      </MetaDataPreviewBoxContainer>
+    </MetaDataPreviewContainer>
+  );
+};
+
+export default MetaDataPreview;
+
+const PreviewHeader = styled.h1`
+  color: ${({ theme }) => theme.colors.dimmed};
+  ${({ theme }) => theme.mobileFonts.Button};
+`;
+
+const MetaDataPreviewContainer = styled.div`
+  margin: 3.2rem 0 0 16.7rem;
+`;
+
+const MetaDataPreviewBoxContainer = styled.div`
+  margin-top: 1.8rem;
+  border: 1px solid #d9d9d9;
+  width: 39.4rem;
+  height: 31.8rem;
+`;
+
+const PreviewBottomContainer = styled.div`
+  margin-left: 3rem;
+  height: 14.2rem;
+`;
+
+const PreviewBlogUrl = styled.p`
+  ${({ theme }) => theme.fonts.Body2_Regular};
+  margin: 0.7rem 0 2.5rem;
+  color: ${({ theme }) => theme.colors.grey_700};
+`;
+
+const PreviewDescription = styled.p`
+  margin-top: 1.5rem;
+  ${({ theme }) => theme.fonts.Body2_Regular};
+  width: 22.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.colors.grey_700};
+`;
+
+const PreviewTitle = styled.p`
+  ${({ theme }) => theme.mobileFonts.Markdown_H2};
+  margin-top: 2.8rem;
+  color: ${({ theme }) => theme.colors.grey_1000};
+`;
+
+const NonePreviewImage = styled.div`
+  background-color: ${({ theme }) => theme.colors.grey_200};
+  width: 39.4rem;
+  height: 15.1rem;
+`;
+
+const PreviewImage = styled.img`
+  width: 39.4rem;
+  height: 15.1rem;
+  object-fit: cover;
+`;

--- a/components/dashboard/blogBasicInfo/BlogMetaDataTitle.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMetaDataTitle.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React, { ChangeEvent } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+
+import { blogMetaDataState } from '../state/blogMetaData';
+
+const BlogMetaDataTitle = () => {
+  const [{ title }, setBlogMetaData] = useRecoilState(blogMetaDataState);
+
+  const handleOnMetaTitleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.currentTarget;
+    setBlogMetaData((prev) => ({ ...prev, title: value }));
+  };
+
+  return (
+    <BlogMetaDataTitleContainer>
+      <MetaDataTitle>메타데이터 제목</MetaDataTitle>
+      <MetaDataTitleTextarea value={title} placeholder="Palmspring 기술 블로그" onChange={handleOnMetaTitleChange} />
+    </BlogMetaDataTitleContainer>
+  );
+};
+
+export default BlogMetaDataTitle;
+
+const MetaDataTitleTextarea = styled.textarea`
+  ${({ theme }) => theme.fonts.Body2_Regular};
+  gap: 1rem;
+  align-items: flex-start;
+  border: 1px solid ${({ theme }) => theme.colors.grey_400};
+  border-radius: 0.8rem;
+  padding: 1rem 1.2rem;
+  width: 64.5rem;
+  height: 4.6rem;
+  resize: none;
+  color: ${({ theme }) => theme.colors.grey_900};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.grey_600};
+  }
+  &:focus {
+    outline: none;
+    border: 1px solid ${({ theme }) => theme.colors.grey_700};
+  }
+`;
+
+const MetaDataTitle = styled.span`
+  ${({ theme }) => theme.fonts.Body2_Semibold};
+  margin: 1rem 6.56rem 0.8rem 0;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.colors.grey_950};
+`;
+
+const BlogMetaDataTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 3.2rem;
+`;

--- a/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
+++ b/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
@@ -1,0 +1,37 @@
+'use client';
+import React from 'react';
+import styled from 'styled-components';
+
+interface BlogSubHeadingProps {
+  mainHeaderText: string;
+  subHeaderText?: string;
+}
+
+const BlogSubHeading = ({ mainHeaderText, subHeaderText }: BlogSubHeadingProps) => {
+  if (subHeaderText) {
+    return (
+      <>
+        <FirstMainHeaderText>{mainHeaderText}</FirstMainHeaderText>
+        <SubHeaderText>{subHeaderText}</SubHeaderText>
+      </>
+    );
+  } else {
+    return <MainHeaderText>{mainHeaderText}</MainHeaderText>;
+  }
+};
+
+export default BlogSubHeading;
+
+const MainHeaderText = styled.h3`
+  ${({ theme }) => theme.fonts.Heading3_Semibold};
+  margin: 2.1rem 0 1.8rem;
+`;
+
+const SubHeaderText = styled.p`
+  margin: 0.6rem 0 3.1rem;
+`;
+
+const FirstMainHeaderText = styled.h3`
+  ${({ theme }) => theme.fonts.Heading3_Semibold};
+  margin-top: 5.4rem;
+`;

--- a/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
+++ b/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
@@ -8,23 +8,21 @@ interface BlogSubHeadingProps {
 }
 
 const BlogSubHeading = ({ mainHeaderText, subHeaderText }: BlogSubHeadingProps) => {
-  if (subHeaderText) {
-    return (
-      <>
-        <FirstMainHeaderText>{mainHeaderText}</FirstMainHeaderText>
-        <SubHeaderText>{subHeaderText}</SubHeaderText>
-      </>
-    );
-  } else {
-    return <MainHeaderText>{mainHeaderText}</MainHeaderText>;
-  }
+  return subHeaderText ? (
+    <>
+      <FirstMainHeaderText>{mainHeaderText}</FirstMainHeaderText>
+      <SubHeaderText>{subHeaderText}</SubHeaderText>
+    </>
+  ) : (
+    <MainHeaderText>{mainHeaderText}</MainHeaderText>
+  );
 };
 
 export default BlogSubHeading;
 
 const MainHeaderText = styled.h3`
-  margin: 2.1rem 0 1.8rem;
   ${({ theme }) => theme.fonts.Heading3_Semibold};
+  margin: 2.1rem 0 1.8rem;
   color: ${({ theme }) => theme.colors.grey_900};
 `;
 

--- a/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
+++ b/components/dashboard/blogBasicInfo/BlogSubHeading.tsx
@@ -23,15 +23,19 @@ const BlogSubHeading = ({ mainHeaderText, subHeaderText }: BlogSubHeadingProps) 
 export default BlogSubHeading;
 
 const MainHeaderText = styled.h3`
-  ${({ theme }) => theme.fonts.Heading3_Semibold};
   margin: 2.1rem 0 1.8rem;
+  ${({ theme }) => theme.fonts.Heading3_Semibold};
+  color: ${({ theme }) => theme.colors.grey_900};
 `;
 
 const SubHeaderText = styled.p`
+  ${({ theme }) => theme.fonts.Body1_Regular};
   margin: 0.6rem 0 3.1rem;
+  color: ${({ theme }) => theme.colors.grey_900};
 `;
 
 const FirstMainHeaderText = styled.h3`
   ${({ theme }) => theme.fonts.Heading3_Semibold};
   margin-top: 5.4rem;
+  color: ${({ theme }) => theme.colors.grey_900};
 `;

--- a/components/dashboard/state/blogMetaData.ts
+++ b/components/dashboard/state/blogMetaData.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+import { BlogMetaData } from '@/types/blogMetaData';
+
+export const blogMetaDataState = atom<BlogMetaData>({
+  key: 'blogMetaDataState',
+  default: {
+    image: '',
+    title: '',
+    description: '',
+  },
+});

--- a/types/blogMetaData.ts
+++ b/types/blogMetaData.ts
@@ -1,0 +1,5 @@
+export interface BlogMetaData {
+  image: string;
+  title: string;
+  description: string;
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #256 

## 💙 작업 내용
- [x] metadata 설정 GUI 작업

## ✅ PR Point
> 대략적으로 블로그마다 다른 동적메타데이터는 아래와 같은 로직으로 하려고 해요!
1. 블로그 기본 설정 -> 메타데이터 정보 사용자에게 입력받기 => recoil에 저장
2. recoil에 저장한 메타데이터 정보는 미리보기에 사용됨
3. 블로그 기본 설정 저장하기 클릭시 서버 통신
4. 각 블로그 head에 서버에서 받아서 뿌려주기 -> Next js dynamic meta tags
(Next js dynamic meta tags 더 찾아보겠숨돠.)

<img width="541" alt="스크린샷 2023-10-01 오전 12 00 12" src="https://github.com/palm-springs/PalmSpringClient/assets/108226647/b66671b5-a6d7-4815-aa1d-776ef49d5147">
<img width="618" alt="스크린샷 2023-10-01 오전 12 00 25" src="https://github.com/palm-springs/PalmSpringClient/assets/108226647/d0b12f7f-7a1b-41ee-abd9-cc04d6afe24c">

- 메타데이터 부분 GUI 추가했습니당!
> 형근이가 예쁘게 만들어놓은 대시보드 컴포넌트 처럼 하나하나 분리해서 최대한 맞추려고 노력했숨니다..!

```
📦blogBasicInfo
 ┣ 📜BlogConfigTemplate.tsx
 ┣ 📜BlogDeleteButton.tsx
 ┣ 📜BlogDescribeText.tsx
 ┣ 📜BlogLogoImage.tsx
 ┣ 📜BlogMainImge.tsx
 ┣ 📜BlogMetaDataDescription.tsx ✔️추가
 ┣ 📜BlogMetaDataImage.tsx✔️추가
 ┣ 📜BlogMetaDataPreview.tsx✔️추가
 ┣ 📜BlogMetaDataTitle.tsx✔️추가
 ┣ 📜BlogName.tsx
 ┣ 📜BlogSubHeading.tsx✔️추가
 ┗ 📜BlogUrl.tsx
```

## 👀 스크린샷 / GIF / 링크

https://github.com/palm-springs/PalmSpringClient/assets/108226647/3b5fd5ac-20cd-4be5-ad87-433cbbd57257

