### PR TITLE
Feat/#257/permisson policy

### DIFF
--- a/components/dashboard/BasicUserInfo/ui/DeleteButton.tsx
+++ b/components/dashboard/BasicUserInfo/ui/DeleteButton.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { updateWithdrawPlatform, updateWithdrawTeam } from '@/api/user';
 import ModalPortal from '@/components/common/ModalPortal';
 import DashboardDeleteModal from '@/components/common/ui/DashboardDeleteModal';
+import usePerMissionPolicy from '@/hooks/usePermissionPolicy';
 
 const DeleteButton = () => {
   const { team } = useParams();
@@ -12,6 +13,8 @@ const DeleteButton = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState('');
+
+  const { withdrawPalmSpring } = usePerMissionPolicy();
 
   // 팜스프링 탈퇴 함수
   const handleWithdrawPlatform = async () => {
@@ -57,9 +60,11 @@ const DeleteButton = () => {
           />
         </ModalPortal>
       )}
-      <LeavingPalms type="button" onClick={() => handleModalType('platform')}>
-        팜스프링 탈퇴하기
-      </LeavingPalms>
+      {withdrawPalmSpring && (
+        <LeavingPalms type="button" onClick={() => handleModalType('platform')}>
+          팜스프링 탈퇴하기
+        </LeavingPalms>
+      )}
       <LeavingBlog type="button" onClick={() => handleModalType('team')}>
         블로그에서 나가기
       </LeavingBlog>

--- a/components/dashboard/BasicUserInfo/ui/DeleteButton.tsx
+++ b/components/dashboard/BasicUserInfo/ui/DeleteButton.tsx
@@ -14,7 +14,7 @@ const DeleteButton = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState('');
 
-  const { withdrawPalmSpring } = usePerMissionPolicy();
+  const { withdrawPalmSpring, resignCurrentTeam } = usePerMissionPolicy();
 
   // 팜스프링 탈퇴 함수
   const handleWithdrawPlatform = async () => {
@@ -65,9 +65,11 @@ const DeleteButton = () => {
           팜스프링 탈퇴하기
         </LeavingPalms>
       )}
-      <LeavingBlog type="button" onClick={() => handleModalType('team')}>
-        블로그에서 나가기
-      </LeavingBlog>
+      {resignCurrentTeam && (
+        <LeavingBlog type="button" onClick={() => handleModalType('team')}>
+          블로그에서 나가기
+        </LeavingBlog>
+      )}
     </DeleteButtonContainer>
   );
 };

--- a/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
+++ b/components/dashboard/blogBasicInfo/BlogConfigTemplate.tsx
@@ -6,6 +6,7 @@ import { styled } from 'styled-components';
 import { putBlogConfig } from '@/api/blog';
 import LoadingLottie from '@/components/common/ui/LoadingLottie';
 import { useGetBlogInfo } from '@/hooks/blog';
+import usePerMissionPolicy from '@/hooks/usePermissionPolicy';
 import { getImageMultipartData } from '@/utils/getImageMultipartData';
 
 import BlogInfoDeleteButton from './BlogDeleteButton';
@@ -26,6 +27,8 @@ const BlogConfigTemplate = () => {
   const { team } = useParams();
 
   const res = useGetBlogInfo(team);
+
+  const { modifyBlogInfo, deleteBlog } = usePerMissionPolicy();
 
   const [blogConfig, setBlogConfig] = useState<BlogConfigProps>({
     blogName: '블로그 이름을 불러오는 중입니다...',
@@ -121,6 +124,7 @@ const BlogConfigTemplate = () => {
       <BlogBasicInfoContainer>
         <BlogUrl blogUrl={res.data.url} />
         <BlogName
+          readonly={!modifyBlogInfo}
           blogName={blogConfig.blogName}
           setBlogName={(v) =>
             setBlogConfig((prev) => ({
@@ -130,6 +134,7 @@ const BlogConfigTemplate = () => {
           }
         />
         <BlogLogoImage
+          readonly={!modifyBlogInfo}
           setFile={(v) =>
             setBlogConfig((prev) => ({
               ...prev,
@@ -139,6 +144,7 @@ const BlogConfigTemplate = () => {
           file={blogConfig.blogLogoImage as string}
         />
         <BlogMainImage
+          readonly={!modifyBlogInfo}
           setFile={(v) =>
             setBlogConfig((prev) => ({
               ...prev,
@@ -148,6 +154,7 @@ const BlogConfigTemplate = () => {
           file={blogConfig.blogMainImage as string}
         />
         <BlogDescribeText
+          readonly={!modifyBlogInfo}
           describeText={blogConfig.blogDescribeText}
           setDescribeText={(v) =>
             setBlogConfig((prev) => ({
@@ -156,10 +163,12 @@ const BlogConfigTemplate = () => {
             }))
           }
         />
-        <BlogInfoDeleteButton />
-        <BlogSaveButton type="button" disabled={blogConfig.blogName === ''} onClick={postBlogConfig}>
-          저장하기
-        </BlogSaveButton>
+        {deleteBlog && <BlogInfoDeleteButton />}
+        {modifyBlogInfo && (
+          <BlogSaveButton type="button" disabled={blogConfig.blogName === ''} onClick={postBlogConfig}>
+            저장하기
+          </BlogSaveButton>
+        )}
       </BlogBasicInfoContainer>
     </>
   );

--- a/components/dashboard/blogBasicInfo/BlogDescribeText.tsx
+++ b/components/dashboard/blogBasicInfo/BlogDescribeText.tsx
@@ -5,10 +5,11 @@ import styled from 'styled-components';
 interface BlogDescribeTextProps {
   describeText: string;
   setDescribeText: (v: string) => void;
+  readonly: boolean;
 }
 
 const BlogDescribeText = (props: BlogDescribeTextProps) => {
-  const { describeText, setDescribeText } = props;
+  const { describeText, setDescribeText, readonly } = props;
 
   const getCurInputTextLineCnt = useCallback((text: string) => {
     const lines = text?.split(/\r|\r\n|\n/);
@@ -25,6 +26,7 @@ const BlogDescribeText = (props: BlogDescribeTextProps) => {
         <BlogDescribeContent>메인 홈에 나타나는 설명입니다.</BlogDescribeContent>
       </BlogDescribeTitleContainer>
       <BlogDescribeTextarea
+        readOnly={readonly}
         $isScrollable={isScrollable}
         value={describeText}
         onChange={(e) => setDescribeText(e.target.value)}

--- a/components/dashboard/blogBasicInfo/BlogLogoImage.tsx
+++ b/components/dashboard/blogBasicInfo/BlogLogoImage.tsx
@@ -8,10 +8,11 @@ import { CloseIcon, UploadIcon } from '@/public/icons';
 interface BlogLogoImageProps {
   file: string;
   setFile: (v: File | null) => void;
+  readonly: boolean;
 }
 
 const BlogLogoImage = (props: BlogLogoImageProps) => {
-  const { file, setFile } = props;
+  const { file, setFile, readonly } = props;
 
   const [preLoadImg, setPreLoadImg] = useState<string>('');
 
@@ -29,6 +30,7 @@ const BlogLogoImage = (props: BlogLogoImageProps) => {
       </ImageGuideContainer>
       <BlogLogoUploadLabel>
         <input
+          readOnly={readonly}
           ref={inputImgRef}
           type="file"
           onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/components/dashboard/blogBasicInfo/BlogMainImge.tsx
+++ b/components/dashboard/blogBasicInfo/BlogMainImge.tsx
@@ -8,10 +8,11 @@ import { CloseIcon, UploadIcon } from '@/public/icons';
 interface BlogMainImageProps {
   file: string;
   setFile: (v: File | null) => void;
+  readonly: boolean;
 }
 
 const BlogMainImage = (props: BlogMainImageProps) => {
-  const { file, setFile } = props;
+  const { file, setFile, readonly } = props;
 
   const [preLoadImg, setPreLoadImg] = useState<string>('');
 
@@ -32,6 +33,7 @@ const BlogMainImage = (props: BlogMainImageProps) => {
       </ImageGuideContainer>
       <BlogMainUploadLabel>
         <input
+          readOnly={readonly}
           ref={inputImgRef}
           type="file"
           onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/components/dashboard/blogBasicInfo/BlogName.tsx
+++ b/components/dashboard/blogBasicInfo/BlogName.tsx
@@ -6,14 +6,15 @@ import styled from 'styled-components';
 interface BlogNameProps {
   blogName: string;
   setBlogName: (v: string) => void;
+  readonly: boolean;
 }
 
 const BlogName = (props: BlogNameProps) => {
-  const { blogName, setBlogName } = props;
+  const { blogName, setBlogName, readonly } = props;
   return (
     <BlogNameContainer>
       <BlogNameTitle>블로그 이름</BlogNameTitle>
-      <BlogNameText value={blogName} onChange={(e) => setBlogName(e.target.value)} />
+      <BlogNameText value={blogName} onChange={(e) => setBlogName(e.target.value)} readOnly={readonly} />
     </BlogNameContainer>
   );
 };

--- a/components/dashboard/components/BlogList.tsx
+++ b/components/dashboard/components/BlogList.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useRouter } from 'next/navigation';
 
 import LoadingLottie from '@/components/common/ui/LoadingLottie';
@@ -20,28 +20,32 @@ const BlogList = (props: BlogListProps) => {
 
   const router = useRouter();
 
+  if (!res) {
+    return (
+      <BlogListContainer>
+        <LoadingLottie width={4} height={4} />
+      </BlogListContainer>
+    );
+  }
+
   return (
     <BlogListContainer>
-      {res ? (
-        <>
-          {res.data.joinBlogList.map(({ name, url }, idx) => {
-            return (
-              <IndivBlog
-                isCurrentBlog={idx === currentBlog}
-                innerText={name}
-                key={name}
-                handleChange={() => {
-                  setCurrentBlog(idx);
-                  router.push(`/${url}/dashboard/upload`);
-                }}
-              />
-            );
-          })}
-          <MakeNewBlogContainer onClick={() => router.push('/create-blog')} />
-        </>
-      ) : (
-        <LoadingLottie width={4} height={4} />
-      )}
+      <>
+        {res.data.joinBlogList.map(({ name, url }, idx) => {
+          return (
+            <IndivBlog
+              isCurrentBlog={idx === currentBlog}
+              innerText={name}
+              key={name}
+              handleChange={() => {
+                setCurrentBlog(idx);
+                router.push(`/${url}/dashboard/upload`);
+              }}
+            />
+          );
+        })}
+        <MakeNewBlogContainer onClick={() => router.push('/create-blog')} />
+      </>
     </BlogListContainer>
   );
 };

--- a/components/dashboard/components/BlogList.tsx
+++ b/components/dashboard/components/BlogList.tsx
@@ -28,10 +28,12 @@ const BlogList = (props: BlogListProps) => {
     );
   }
 
+  const userData = res.data;
+
   return (
     <BlogListContainer>
       <>
-        {res.data.joinBlogList.map(({ name, url }, idx) => {
+        {userData.joinBlogList.map(({ name, url }, idx) => {
           return (
             <IndivBlog
               isCurrentBlog={idx === currentBlog}

--- a/components/dashboard/components/DashBoardFooter.tsx
+++ b/components/dashboard/components/DashBoardFooter.tsx
@@ -7,6 +7,7 @@ import { useResetRecoilState } from 'recoil';
 import { accessTokenState } from '@/components/auth/states/atom';
 import LoadingLottie from '@/components/common/ui/LoadingLottie';
 import { useGetUserInfo } from '@/hooks/dashboard';
+import userState from '@/recoil/atom/user';
 
 import DashBoardFooterContainer from './ui/DashBoardFooterContainer';
 import DashBoardProfileContainer from './ui/DashBoardProfileContainer';
@@ -16,6 +17,7 @@ import DashBoardNavBtn from './DashBoardNavBtn';
 const DashBoardFooter = () => {
   const [isPopOverMenuOpen, setIsPopOverMenuOpen] = useState<boolean>(false);
   const resetAccessToken = useResetRecoilState(accessTokenState);
+  const resetUserState = useResetRecoilState(userState);
   const sessionStorage = typeof window !== 'undefined' ? window.sessionStorage : undefined;
 
   const router = useRouter();
@@ -26,6 +28,7 @@ const DashBoardFooter = () => {
 
   const handleLogOut = () => {
     resetAccessToken();
+    resetUserState();
     sessionStorage?.removeItem('userToken');
     router.push('/auth');
   };

--- a/hooks/dashboard.ts
+++ b/hooks/dashboard.ts
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRecoilState } from 'recoil';
 
 import {
   deleteArticle,
@@ -18,6 +20,7 @@ import {
   updateNavigation,
   updateUserInfo,
 } from '@/api/dashboard';
+import userState from '@/recoil/atom/user';
 import { UserBasicInfo } from '@/types/user';
 
 import { QUERY_KEY_ARTICLE } from './editor';
@@ -66,7 +69,19 @@ export const useGetTempSavedList = (blogUrl: string) => {
 };
 
 export const useGetUserInfo = () => {
-  const { data } = useQuery([QUERY_KEY_DASHBOARD.getUserInfo], () => getUserInfo());
+  const { data, isSuccess } = useQuery([QUERY_KEY_DASHBOARD.getUserInfo], () => getUserInfo());
+
+  const [userValue, setUserState] = useRecoilState(userState);
+
+  useEffect(() => {
+    if (!userValue && isSuccess) {
+      setUserState({
+        ...data.data,
+        role: '관리자',
+      });
+    }
+  }, [isSuccess, data]);
+
   return data;
 };
 

--- a/hooks/dashboard.ts
+++ b/hooks/dashboard.ts
@@ -77,7 +77,7 @@ export const useGetUserInfo = () => {
     if (!userValue && isSuccess) {
       setUserState({
         ...data.data,
-        role: '관리자',
+        role: '소유자',
       });
     }
   }, [isSuccess, data]);

--- a/hooks/dashboard.ts
+++ b/hooks/dashboard.ts
@@ -77,7 +77,7 @@ export const useGetUserInfo = () => {
     if (!userValue && isSuccess) {
       setUserState({
         ...data.data,
-        role: '소유자',
+        role: '편집자',
       });
     }
   }, [isSuccess, data]);

--- a/hooks/usePermissionPolicy.ts
+++ b/hooks/usePermissionPolicy.ts
@@ -1,0 +1,16 @@
+import { useRecoilValue } from 'recoil';
+
+import userRoleSelector from '@/recoil/selector/userRoleSelector';
+import PermissionPolicyChecker from '@/utils/PermissionPolicyClass';
+
+const usePerMissionPolicy = () => {
+  const userRole = useRecoilValue(userRoleSelector);
+
+  if (!userRole) throw new Error('유저가 없습니다. 다시 로그인해주세요!');
+
+  const UserPermissionPolicyChecker = PermissionPolicyChecker.getInstance(userRole);
+
+  return UserPermissionPolicyChecker;
+};
+
+export default usePerMissionPolicy;

--- a/hooks/usePermissionPolicy.ts
+++ b/hooks/usePermissionPolicy.ts
@@ -1,12 +1,18 @@
+import { useRouter } from 'next/navigation';
 import { useRecoilValue } from 'recoil';
 
 import userRoleSelector from '@/recoil/selector/userRoleSelector';
 import PermissionPolicyChecker from '@/utils/PermissionPolicyClass';
 
 const usePerMissionPolicy = () => {
+  const router = useRouter();
+
   const userRole = useRecoilValue(userRoleSelector);
 
-  if (!userRole) throw new Error('유저가 없습니다. 다시 로그인해주세요!');
+  if (!userRole) {
+    router.push('/auth');
+    throw new Error('유저가 없습니다. 다시 로그인해주세요!');
+  }
 
   const UserPermissionPolicyChecker = PermissionPolicyChecker.getInstance(userRole);
 

--- a/hooks/usePermissionPolicy.ts
+++ b/hooks/usePermissionPolicy.ts
@@ -1,20 +1,16 @@
-import { useRouter } from 'next/navigation';
 import { useRecoilValue } from 'recoil';
 
 import userRoleSelector from '@/recoil/selector/userRoleSelector';
 import PermissionPolicyChecker from '@/utils/PermissionPolicyClass';
 
 const usePerMissionPolicy = () => {
-  const router = useRouter();
-
   const userRole = useRecoilValue(userRoleSelector);
 
   if (!userRole) {
-    router.push('/auth');
     throw new Error('유저가 없습니다. 다시 로그인해주세요!');
   }
 
-  const UserPermissionPolicyChecker = PermissionPolicyChecker.getInstance(userRole);
+  const UserPermissionPolicyChecker = userRole && PermissionPolicyChecker.getInstance(userRole);
 
   return UserPermissionPolicyChecker;
 };

--- a/recoil/atom/user.ts
+++ b/recoil/atom/user.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+
+import { UserInfoProps } from '@/types/user';
+
+const userState = atom<UserInfoProps | null>({
+  key: 'userState',
+  default: null,
+});
+
+export default userState;

--- a/recoil/selector/userRoleSelector.ts
+++ b/recoil/selector/userRoleSelector.ts
@@ -1,0 +1,10 @@
+import { selector } from 'recoil';
+
+import userState from '../atom/user';
+
+const userRoleSelector = selector({
+  key: 'userRoleSelector',
+  get: ({ get }) => get(userState)?.role,
+});
+
+export default userRoleSelector;

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,3 +1,5 @@
+import { RoleType } from '@/utils/PermissionPolicyClass';
+
 export interface UserInfoProps {
   name: string;
   email: string;
@@ -6,6 +8,7 @@ export interface UserInfoProps {
     name: string;
     url: string;
   }>;
+  role: RoleType;
 }
 
 export interface UserBasicInfo {

--- a/utils/PermissionPolicyClass.ts
+++ b/utils/PermissionPolicyClass.ts
@@ -1,0 +1,13 @@
+class PermissionPolicy {
+  private role: '소유자' | '관리자' | '편집자';
+
+  constructor({ role }: { role: '소유자' | '관리자' | '편집자' }) {
+    this.role = role;
+  }
+
+  get userCanAccess() {
+    return this.role === '관리자';
+  }
+}
+
+export default PermissionPolicy;

--- a/utils/PermissionPolicyClass.ts
+++ b/utils/PermissionPolicyClass.ts
@@ -1,13 +1,84 @@
-class PermissionPolicy {
-  private role: '소유자' | '관리자' | '편집자';
+export type RoleType = '소유자' | '관리자' | '편집자';
 
-  constructor({ role }: { role: '소유자' | '관리자' | '편집자' }) {
-    this.role = role;
+// <T extends boolean, S extends ((roles: RoleType[]) => T)>
+
+class PermissionPolicyChecker {
+  private static instance: PermissionPolicyChecker;
+  /**
+   * 권한은 크게 두 종류로 나눌 수 있습니다.
+   * 1. 해당 권한인 경우에만 가능한 것
+   * 2. 해당 권한인 경우에만 불가능한 것
+   *
+   * 이를 위해 메서드를 두 가지로 분리했습니다.
+   */
+  private _role: RoleType;
+
+  constructor(role: RoleType) {
+    this._role = role;
   }
 
-  get userCanAccess() {
-    return this.role === '관리자';
+  // 이 권한을 가진 경우만 가능합니다.
+  private eligible(roles: RoleType[]) {
+    return roles.includes(this._role);
+  }
+
+  // 이 권한을 가진 경우만 불가능합니다.
+  private ineligible(roles: RoleType[]) {
+    return !roles.includes(this._role);
+  }
+
+  // 업로드된 글 삭제
+  get deleteUploadedContent() {
+    return this.eligible(['소유자', '관리자']);
+  }
+
+  // 임시저장한 글 삭제
+  get deleteNonUploadedContent() {
+    return this.eligible(['소유자', '관리자']);
+  }
+
+  // 팜스프링 탈퇴하기
+  get withdrawPalmSpring() {
+    return this.ineligible(['소유자']);
+  }
+
+  // 블로그 나가기(팀 퇴사하기)
+  get resignCurrentTeam() {
+    return this.ineligible(['소유자']);
+  }
+
+  // 블로그 삭제하기
+  get deleteBlog() {
+    return this.eligible(['소유자']);
+  }
+
+  // 팀원 초대하기
+  get inviteNewMember() {
+    return this.eligible(['소유자', '관리자']);
+  }
+
+  // 편집자 추방하기
+  get expelEditor() {
+    return this.eligible(['소유자', '관리자']);
+  }
+
+  // 관리자 추방하기
+  get expelManager() {
+    return this.eligible(['소유자']);
+  }
+
+  // 관리자 임명하기
+  get appointManager() {
+    return this.eligible(['소유자']);
+  }
+
+  // 싱글톤 패턴 적용
+  static getInstance(role: RoleType) {
+    if (!PermissionPolicyChecker.instance) {
+      PermissionPolicyChecker.instance = new PermissionPolicyChecker(role);
+    }
+    return PermissionPolicyChecker.instance;
   }
 }
 
-export default PermissionPolicy;
+export default PermissionPolicyChecker;

--- a/utils/PermissionPolicyClass.ts
+++ b/utils/PermissionPolicyClass.ts
@@ -1,9 +1,16 @@
 export type RoleType = '소유자' | '관리자' | '편집자';
 
-// <T extends boolean, S extends ((roles: RoleType[]) => T)>
-
 class PermissionPolicyChecker {
   private static instance: PermissionPolicyChecker;
+
+  // 싱글톤 패턴 적용
+  static getInstance(role: RoleType) {
+    if (!PermissionPolicyChecker.instance) {
+      PermissionPolicyChecker.instance = new PermissionPolicyChecker(role);
+    }
+    return PermissionPolicyChecker.instance;
+  }
+
   /**
    * 권한은 크게 두 종류로 나눌 수 있습니다.
    * 1. 해당 권한인 경우에만 가능한 것
@@ -11,21 +18,21 @@ class PermissionPolicyChecker {
    *
    * 이를 위해 메서드를 두 가지로 분리했습니다.
    */
-  private _role: RoleType;
+  private readonly _role: RoleType;
 
   constructor(role: RoleType) {
     this._role = role;
   }
 
   // 이 권한을 가진 경우만 가능합니다.
-  private eligible(roles: RoleType[]) {
+  private eligible = (roles: RoleType[]) => {
     return roles.includes(this._role);
-  }
+  };
 
   // 이 권한을 가진 경우만 불가능합니다.
-  private ineligible(roles: RoleType[]) {
+  private ineligible = (roles: RoleType[]) => {
     return !roles.includes(this._role);
-  }
+  };
 
   // 업로드된 글 삭제
   get deleteUploadedContent() {
@@ -70,14 +77,6 @@ class PermissionPolicyChecker {
   // 관리자 임명하기
   get appointManager() {
     return this.eligible(['소유자']);
-  }
-
-  // 싱글톤 패턴 적용
-  static getInstance(role: RoleType) {
-    if (!PermissionPolicyChecker.instance) {
-      PermissionPolicyChecker.instance = new PermissionPolicyChecker(role);
-    }
-    return PermissionPolicyChecker.instance;
   }
 }
 

--- a/utils/PermissionPolicyClass.ts
+++ b/utils/PermissionPolicyClass.ts
@@ -78,6 +78,10 @@ class PermissionPolicyChecker {
   get appointManager() {
     return this.eligible(['소유자']);
   }
+
+  get modifyBlogInfo() {
+    return this.eligible(['소유자', '관리자']);
+  }
 }
 
 export default PermissionPolicyChecker;


### PR DESCRIPTION
## 🔥 Related Issues
- close #257 

## 💙 작업 내용
- [x] ~ 권한 설정 및 컨트롤을 위한 PermissionPolicyClass 생성
- [x] ~ PermissionPolicy 분기처리를 위한 전역 user recoil atom 생성
- [x] ~ 프론트에서 가능한 분기처리 진행(커밋 확인 부탁드립니다!)

## ✅ PR Point
- 권한 분기용 순수함수로 이루어진 PermissionPolicyClass를 통해 전체 권한에 대한 분기처리를 진행했습니다.
- 유저 정보가 담긴 전역 atom을 생성했고, 이 중 role 만 가져오는 selector를 생성했습니다.
- usePermissionPolicy 커스텀 훅 내부에서 selector를 이용해 role을 가져오도록 해주었고,해당 role을 PermissionPolicyClass에 넣어 권한들을 확인할 수 있도록 했습니다.
- class 내부적으로 중복되는 타입을 제네릭으로 묶어버리고 싶은데, 생각보다 쉽지 않아서 우선 인터페이스로 묶었습니다. 좋은 방법을 알고 계시다면 말씀해주시면 감사하겠습니다!
- 프론트에서 진행 가능한 분기처리들을 간단하게 진행했고, 이외에는 서버 작업이 마무리되는대로 api 명세서를 확인한 뒤 작업해야할 것 같아서 우선 끊고 pr 날립니다!
