### PR TITLE
Feat/#299/user

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,10 +1,9 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 
 import { getAccessTokenProps, googleAccessTokenResponse, jwtAccessTokenResponse } from '@/types/auth';
 import { Response } from '@/types/common';
 
 import client, { refreshAxiosInstance } from '.';
-
 // 구글 액세스 토큰 발급
 export const getAccessToken = async (props: getAccessTokenProps) => {
   const { clientId, clientSecret, code } = props;
@@ -23,14 +22,21 @@ grant_type=authorization_code`,
 
 // JWT 토큰 발급
 export const postSocialLogin = async (platform: string, AccessToken: string) => {
-  const { data } = await client.post<Response<jwtAccessTokenResponse>>(
-    `/api/v2/auth/social/login/${platform}`,
-    {
-      accessToken: AccessToken,
-    },
-    { withCredentials: true },
-  );
-  return data;
+  try {
+    const { data } = await client.post<Response<jwtAccessTokenResponse>>(
+      `/api/v2/auth/social/login/${platform}`,
+      {
+        accessToken: AccessToken,
+      },
+      { withCredentials: true },
+    );
+    return data;
+  } catch (err) {
+    if (isAxiosError(err)) {
+      return err.response.data;
+    }
+    return;
+  }
 };
 
 // 리프레시 토큰 재발급

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -33,7 +33,7 @@ export const postSocialLogin = async (platform: string, AccessToken: string) => 
     return data;
   } catch (err) {
     if (isAxiosError(err)) {
-      return err.response.data;
+      return err.response?.data;
     }
     return;
   }

--- a/api/user.ts
+++ b/api/user.ts
@@ -33,7 +33,7 @@ export const deleteMember = async (blogUrl: string, memberId: string, email: str
 
 // 팀원 초대하기
 export const postMemberInvite = async (blogUrl: string, requestBody: InviteRequestBody) => {
-  const { data } = await client.post<Response<UserInvite>>(`/api/v2/dashboard/user/invite/${blogUrl}`, requestBody);
+  const { data } = await client.post<Response<null>>(`/api/v2/dashboard/user/invite/${blogUrl}`, requestBody);
   return data;
 };
 // 초대 조회하기

--- a/api/user.ts
+++ b/api/user.ts
@@ -1,5 +1,5 @@
 import { Response } from '@/types/common';
-import { InviteRequestBody, UserInfoProps, UserInvite, UserInviteInfo } from '@/types/user';
+import { DeleteRequestBody, InviteRequestBody, UserInfoProps, UserInviteInfo } from '@/types/user';
 
 import client from '.';
 
@@ -36,6 +36,7 @@ export const postMemberInvite = async (blogUrl: string, requestBody: InviteReque
   const { data } = await client.post<Response<null>>(`/api/v2/dashboard/user/invite/${blogUrl}`, requestBody);
   return data;
 };
+
 // 초대 조회하기
 export const getMemberInvite = async (code: string | null) => {
   if (!code) return;
@@ -49,5 +50,13 @@ export const getMemberInvite = async (code: string | null) => {
       }
       return { message: null, code: 400, data: null };
     });
+  return data;
+};
+
+// 초대 삭제하기
+export const deleteInvite = async (blogUrl: string, requestBody: DeleteRequestBody) => {
+  const { data } = await client.delete<Response<null>>(`/api/v2/dashboard/user/invite/${blogUrl}`, {
+    data: { ...requestBody },
+  });
   return data;
 };

--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -6,6 +6,7 @@ import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import client, { refreshAxiosInstance } from '@/api';
 import { getRefreshToken } from '@/api/auth';
+import { LoginUserState } from '@/types/auth';
 
 import { accessTokenState } from './states/atom';
 
@@ -33,7 +34,7 @@ const AuthRequired = ({ children }: { children: React.ReactNode }) => {
       console.log('사용자 X');
       const redirectUrl = pathname === '/invite' ? `${pathname}?code=${paramsCode}` : `${pathname}`;
       sessionStorage?.setItem('redirectUrl', redirectUrl);
-      router.push(`/auth?userState=noUser`);
+      router.push(`/auth?userState=${LoginUserState.NO_USER}`);
     }
   }, []);
 

--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -18,10 +18,10 @@ const AuthRequired = ({ children }: { children: React.ReactNode }) => {
   const sessionStorage = typeof window !== 'undefined' ? window.sessionStorage : undefined;
   const setAccessToken = useSetRecoilState(accessTokenState);
   const resetAccessToken = useResetRecoilState(accessTokenState);
+
   const paramsCode = searchParams.get('code');
 
   useEffect(() => {
-    console.log('useEffect');
     // sessionStorage에서 token 가져오기
     const accessToken = sessionStorage?.getItem('userToken');
     if (accessToken) {
@@ -30,10 +30,10 @@ const AuthRequired = ({ children }: { children: React.ReactNode }) => {
       client.defaults.headers.common.Authorization = `Bearer ${accessTokenState}`;
     } else {
       // token 없으면 redirectUrl 저장
-      console.log('야야야야ㅑ야야야야야');
-      const params = `?code=${paramsCode}`;
-      sessionStorage?.setItem('redirectUrl', `${pathname}${paramsCode && params}`);
-      router.push(`/auth`);
+      console.log('사용자 X');
+      const redirectUrl = pathname === '/invite' ? `${pathname}?code=${paramsCode}` : `${pathname}`;
+      sessionStorage?.setItem('redirectUrl', redirectUrl);
+      router.push(`/auth?userState=noUser`);
     }
   }, []);
 

--- a/components/auth/LoginLanding.tsx
+++ b/components/auth/LoginLanding.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 import { LogoIcon } from '@/public/icons';
 import { GoogleImg } from '@/public/images';
-import { authClientInfo } from '@/types/auth';
+import { authClientInfo, LoginUserState } from '@/types/auth';
 import { createToast } from '@/utils/lib/toast';
 
 const LoginLanding = (props: authClientInfo) => {
@@ -23,13 +23,13 @@ const LoginLanding = (props: authClientInfo) => {
 
   useEffect(() => {
     switch (redirectState) {
-      case 'inviteMismatch':
+      case LoginUserState.INVITE_MISMATCH:
         inviteErrorNotify();
         break;
-      case 'noUser':
+      case LoginUserState.NO_USER:
         noUserErrorNotify();
         break;
-      case 'wrongPlatform':
+      case LoginUserState.WRONG_PLATFORM:
         wrongPlatformNotify();
         break;
     }

--- a/components/auth/LoginLanding.tsx
+++ b/components/auth/LoginLanding.tsx
@@ -50,6 +50,24 @@ const LoginLanding = (props: authClientInfo) => {
     });
   };
 
+  const wrongPlatformNotify = () => {
+    toast.error('Gmail 계정만 사용 가능합니다.', {
+      duration: 3000,
+      id: 'error on modifying invite link',
+      style: {
+        padding: '1.6rem 2rem',
+        borderRadius: '3.2rem',
+        background: '#343A40',
+        color: '#fff',
+        fontSize: '1.4rem',
+        fontFamily: 'Pretendard',
+        fontStyle: 'normal',
+        fontWeight: '700',
+        letterSpacing: '-0.028rem',
+      },
+    });
+  };
+
   useEffect(() => {
     switch (redirectState) {
       case 'inviteMismatch':
@@ -57,6 +75,9 @@ const LoginLanding = (props: authClientInfo) => {
         break;
       case 'noUser':
         noUserErrorNotify();
+        break;
+      case 'wrongPlatform':
+        wrongPlatformNotify();
         break;
     }
   }, []);

--- a/components/auth/LoginLanding.tsx
+++ b/components/auth/LoginLanding.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import toast, { Toaster } from 'react-hot-toast';
+import { Toaster } from 'react-hot-toast';
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import styled from 'styled-components';
@@ -9,64 +9,17 @@ import styled from 'styled-components';
 import { LogoIcon } from '@/public/icons';
 import { GoogleImg } from '@/public/images';
 import { authClientInfo } from '@/types/auth';
+import { createToast } from '@/utils/lib/toast';
 
 const LoginLanding = (props: authClientInfo) => {
   const { clientId } = props;
   const redirectState = useSearchParams().get('userState');
 
-  const inviteErrorNotify = () => {
-    toast.error('초대된 사용자가 아닙니다. 다시 로그인해주세요.', {
-      duration: 3000,
-      id: 'error on modifying invite link',
-      style: {
-        padding: '1.6rem 2rem',
-        borderRadius: '3.2rem',
-        background: '#343A40',
-        color: '#fff',
-        fontSize: '1.4rem',
-        fontFamily: 'Pretendard',
-        fontStyle: 'normal',
-        fontWeight: '700',
-        letterSpacing: '-0.028rem',
-      },
-    });
-  };
+  const inviteErrorNotify = createToast('초대된 사용자가 아닙니다. 다시 로그인해주세요.', 'invalid invited error');
 
-  const noUserErrorNotify = () => {
-    toast.error('로그인이 필요합니다.', {
-      duration: 3000,
-      id: 'error on modifying invite link',
-      style: {
-        padding: '1.6rem 2rem',
-        borderRadius: '3.2rem',
-        background: '#343A40',
-        color: '#fff',
-        fontSize: '1.4rem',
-        fontFamily: 'Pretendard',
-        fontStyle: 'normal',
-        fontWeight: '700',
-        letterSpacing: '-0.028rem',
-      },
-    });
-  };
+  const noUserErrorNotify = createToast('로그인이 필요합니다.', 'no user');
 
-  const wrongPlatformNotify = () => {
-    toast.error('Gmail 계정만 사용 가능합니다.', {
-      duration: 3000,
-      id: 'error on modifying invite link',
-      style: {
-        padding: '1.6rem 2rem',
-        borderRadius: '3.2rem',
-        background: '#343A40',
-        color: '#fff',
-        fontSize: '1.4rem',
-        fontFamily: 'Pretendard',
-        fontStyle: 'normal',
-        fontWeight: '700',
-        letterSpacing: '-0.028rem',
-      },
-    });
-  };
+  const wrongPlatformNotify = createToast('Gmail 계정만 사용 가능합니다.', 'login platform');
 
   useEffect(() => {
     switch (redirectState) {

--- a/components/auth/LoginLanding.tsx
+++ b/components/auth/LoginLanding.tsx
@@ -12,9 +12,9 @@ import { authClientInfo } from '@/types/auth';
 
 const LoginLanding = (props: authClientInfo) => {
   const { clientId } = props;
-  const redirectState = useSearchParams().get('state');
+  const redirectState = useSearchParams().get('userState');
 
-  const errorNotify = () => {
+  const inviteErrorNotify = () => {
     toast.error('초대된 사용자가 아닙니다. 다시 로그인해주세요.', {
       duration: 3000,
       id: 'error on modifying invite link',
@@ -32,9 +32,32 @@ const LoginLanding = (props: authClientInfo) => {
     });
   };
 
+  const noUserErrorNotify = () => {
+    toast.error('로그인이 필요합니다.', {
+      duration: 3000,
+      id: 'error on modifying invite link',
+      style: {
+        padding: '1.6rem 2rem',
+        borderRadius: '3.2rem',
+        background: '#343A40',
+        color: '#fff',
+        fontSize: '1.4rem',
+        fontFamily: 'Pretendard',
+        fontStyle: 'normal',
+        fontWeight: '700',
+        letterSpacing: '-0.028rem',
+      },
+    });
+  };
+
   useEffect(() => {
-    if (redirectState === 'userMismatch') {
-      errorNotify();
+    switch (redirectState) {
+      case 'inviteMismatch':
+        inviteErrorNotify();
+        break;
+      case 'noUser':
+        noUserErrorNotify();
+        break;
     }
   }, []);
   // 구글 로그인창 호출

--- a/components/auth/RequestAccessToken.ts
+++ b/components/auth/RequestAccessToken.ts
@@ -20,10 +20,11 @@ const RequestAccessToken = (props: getAccessTokenProps) => {
   const login = async () => {
     if (platformData) {
       const data = await postSocialLogin('google', platformData?.access_token);
-      const { accessToken } = data.data;
-      setAccessToken(accessToken);
+      if (!data) return;
 
       if (data.code === 200) {
+        const { accessToken } = data.data;
+        setAccessToken(accessToken);
         if (redirectUrl) {
           sessionStorage?.removeItem('redirectUrl');
           router.replace(redirectUrl);
@@ -35,6 +36,8 @@ const RequestAccessToken = (props: getAccessTokenProps) => {
             router.push(`/${data.joinBlogList[0].blogUrl}/dashboard/upload`);
           }
         }
+      } else {
+        router.replace('/auth?userState=wrongPlatform');
       }
     }
   };

--- a/components/auth/RequestAccessToken.ts
+++ b/components/auth/RequestAccessToken.ts
@@ -5,7 +5,7 @@ import { useSetRecoilState } from 'recoil';
 import { postSocialLogin } from '@/api/auth';
 import { getUserInfoAfterLogin } from '@/api/dashboard';
 import { useGetAccessToken } from '@/hooks/auth';
-import { getAccessTokenProps } from '@/types/auth';
+import { getAccessTokenProps, LoginUserState } from '@/types/auth';
 
 import { accessTokenState } from './states/atom';
 
@@ -37,7 +37,7 @@ const RequestAccessToken = (props: getAccessTokenProps) => {
           }
         }
       } else {
-        router.replace('/auth?userState=wrongPlatform');
+        router.replace(`/auth?userState=${LoginUserState.WRONG_PLATFORM}`);
       }
     }
   };

--- a/components/common/ui/AddMemberForm.tsx
+++ b/components/common/ui/AddMemberForm.tsx
@@ -51,7 +51,7 @@ const AddMemberForm = (props: AddMemberFormProps) => {
       <ErrorContainer>
         {isError && (
           <>
-            <ErrorMsg> 올바른 이메일 형식을 입력해주세요.</ErrorMsg>
+            <ErrorMsg>@gmail.com 형식으로 입력해주세요.</ErrorMsg>
             <RemoveErrorButton onClick={removeAllError}>오류 제거하기</RemoveErrorButton>
           </>
         )}

--- a/components/dashboard/member/ui/Member.tsx
+++ b/components/dashboard/member/ui/Member.tsx
@@ -2,9 +2,11 @@
 
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import Image from 'next/image';
+import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 
 import ModalPortal from '@/components/common/ModalPortal';
+import { useDeleteInvite } from '@/hooks/auth';
 import { ArrowDownSmallIcon, CharmMenuMeatballIcon, IcClose24Icon, IcUserIcon } from '@/public/icons';
 import { MemberExampleImg } from '@/public/images';
 import { RoleType } from '@/utils/PermissionPolicyClass';
@@ -46,8 +48,14 @@ const Member = (props: MemberComponentProps) => {
   const [showCancelInviteModal, setShowCancelInviteModal] = useState<boolean>(false);
 
   const memberRole = role === 'OWNER' ? '소유자' : role === 'MANAGER' ? '관리자' : '편집자';
+  const { team } = useParams();
+  const { mutate: cancelInvite } = useDeleteInvite(team, { id: Number(memberId), email });
 
   const modalCloseHandler = () => {
+    setShowCancelInviteModal(false);
+  };
+  const handleDeleteInvite = () => {
+    cancelInvite();
     setShowCancelInviteModal(false);
   };
 
@@ -72,6 +80,7 @@ const Member = (props: MemberComponentProps) => {
               leftButtonText={'유지하기'}
               rightButtonText={'초대 취소'}
               leftHandler={modalCloseHandler}
+              rightHandler={handleDeleteInvite}
             />
           </ModalPortal>
         )}

--- a/components/dashboard/member/ui/MemberTemplate.tsx
+++ b/components/dashboard/member/ui/MemberTemplate.tsx
@@ -31,13 +31,18 @@ const MemberTemplate = () => {
   const emailList = emailDataList.map(({ emailValue }) => {
     return emailValue;
   });
-  const { mutate: inviteMember } = usePostMemberInvite(team, { inviteEmails: emailList });
+
+  const resetEmailDataList = () => {
+    setEmailDataList([]);
+  };
+
+  const { mutate: inviteMember } = usePostMemberInvite(team, { inviteEmails: emailList }, resetEmailDataList);
 
   const handleOnClickInvite = () => {
     inviteMember();
     setModalState('');
-    setEmailDataList([]);
   };
+
   useEffect(() => {
     res && console.log(res.data);
   }, [res]);

--- a/components/dashboard/member/ui/MemberTemplate.tsx
+++ b/components/dashboard/member/ui/MemberTemplate.tsx
@@ -53,7 +53,7 @@ const MemberTemplate = () => {
             <DashboardCreateModal
               mainText="팀원 초대하기"
               buttonText="초대하기"
-              subText="쉼표, 엔터, 스페이스바로 메일 주소를 구분할 수 있습니다"
+              subText="쉼표, 엔터, 스페이스바로 메일 주소를 구분할 수 있습니다. &nbsp;&nbsp; 현재 Gmail 계정만 초대 가능합니다."
               buttonHandler={handleOnClickInvite}
               onModalCloseBtnClick={() => setModalState('')}
               disabled={emailDataList.length === 0 || isError}>

--- a/components/invite/InviteLanding.tsx
+++ b/components/invite/InviteLanding.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import { useGetMemberInvite } from '@/hooks/auth';
+import { LoginUserState } from '@/types/auth';
 
 import LoadingLottie from '../common/ui/LoadingLottie';
 
@@ -27,7 +28,7 @@ const InviteAcceptLanding = () => {
     // 초대 사용자와 로그인 사용자 불일치
     if (data.code === 403) {
       sessionStorage?.setItem('redirectUrl', `${pathname}?code=${code}`);
-      router.push(`/auth?userState=inviteMismatch`);
+      router.push(`/auth?userState=${LoginUserState.INVITE_MISMATCH}`);
     }
     // 유효하지 않은 초대 링크
     else if (data.code === 404) {

--- a/components/invite/InviteLanding.tsx
+++ b/components/invite/InviteLanding.tsx
@@ -27,7 +27,7 @@ const InviteAcceptLanding = () => {
     // 초대 사용자와 로그인 사용자 불일치
     if (data.code === 403) {
       sessionStorage?.setItem('redirectUrl', `${pathname}?code=${code}`);
-      router.push(`/auth?state=userMismatch`);
+      router.push(`/auth?userState=inviteMismatch`);
     }
     // 유효하지 않은 초대 링크
     else if (data.code === 404) {

--- a/hooks/auth.ts
+++ b/hooks/auth.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getAccessToken } from '@/api/auth';
-import { getMemberInvite, postMemberInvite } from '@/api/user';
+import { deleteInvite, getMemberInvite, postMemberInvite } from '@/api/user';
 import { getAccessTokenProps } from '@/types/auth';
-import { InviteRequestBody } from '@/types/user';
+import { DeleteRequestBody, InviteRequestBody } from '@/types/user';
 
 import { QUERY_KEY_DASHBOARD } from './dashboard';
 
@@ -25,4 +25,13 @@ export const usePostMemberInvite = (blogUrl: string, requestBody: InviteRequestB
 export const useGetMemberInvite = (code: string | null) => {
   const { data } = useQuery(['invite'], () => getMemberInvite(code));
   return data;
+};
+
+export const useDeleteInvite = (blogUrl: string, requestBody: DeleteRequestBody) => {
+  const queryClient = useQueryClient();
+  return useMutation(() => deleteInvite(blogUrl, requestBody), {
+    onSuccess() {
+      queryClient.invalidateQueries([QUERY_KEY_DASHBOARD.getMemberInfo]);
+    },
+  });
 };

--- a/hooks/auth.ts
+++ b/hooks/auth.ts
@@ -12,11 +12,12 @@ export const useGetAccessToken = (props: getAccessTokenProps) => {
   return data;
 };
 
-export const usePostMemberInvite = (blogUrl: string, requestBody: InviteRequestBody) => {
+export const usePostMemberInvite = (blogUrl: string, requestBody: InviteRequestBody, handleEmailList: () => void) => {
   const queryClient = useQueryClient();
   return useMutation(() => postMemberInvite(blogUrl, requestBody), {
     onSuccess() {
       queryClient.invalidateQueries([QUERY_KEY_DASHBOARD.getMemberInfo]);
+      handleEmailList();
     },
   });
 };

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -20,3 +20,9 @@ export interface jwtAccessTokenResponse {
   grantType: string;
   refreshToken: string;
 }
+
+export enum LoginUserState {
+  NO_USER = 'noUser',
+  WRONG_PLATFORM = 'wrongPlatform',
+  INVITE_MISMATCH = 'inviteMismatch',
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -48,3 +48,8 @@ export interface InviteInfoProps {
   handleOnChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   handleOnFocus: (type: string, value: boolean) => void;
 }
+
+export interface DeleteRequestBody {
+  id: number;
+  email: string;
+}

--- a/utils/checkEmailForm.ts
+++ b/utils/checkEmailForm.ts
@@ -1,8 +1,11 @@
 // 이메일 유효성 검증 함수
 const checkEmailForm = (emailValue: string) => {
-  const regularExpression =
-    /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
+  // 이메일 형식 정규표현식
+  // const regularExpression =
+  //   /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
 
+  // @gmail.com 정규표현식 (임시)
+  const regularExpression = /^[\w.-]+@gmail\.com$/;
   return regularExpression.test(String(emailValue).toLowerCase());
 };
 

--- a/utils/lib/toast.ts
+++ b/utils/lib/toast.ts
@@ -1,0 +1,21 @@
+import toast from 'react-hot-toast';
+
+export const createToast = (message: string, errorType: string) => {
+  return () => {
+    toast.error(message, {
+      duration: 3000,
+      id: `error on ${errorType}`,
+      style: {
+        padding: '1.6rem 2rem',
+        borderRadius: '3.2rem',
+        background: '#343A40',
+        color: '#fff',
+        fontSize: '1.4rem',
+        fontFamily: 'Pretendard',
+        fontStyle: 'normal',
+        fontWeight: '700',
+        letterSpacing: '-0.028rem',
+      },
+    });
+  };
+};


### PR DESCRIPTION
## 🔥 Related Issues
- close #299

## 💙 작업 내용
- [x] 초대 취소하기 API 연결
- [x] gmail 이외 계정 로그인 막기
- [x] gmail 이외 계정 초대 막기
- [x] 사용자 없을시 로그인 리다이렉트 후 토스트 

## ✅ PR Point
- 새로 기능 구현한 부분이 많고 임시로 gmail 계정만 허용되도록 한 부분들이 있습니다.
- 로그인 화면으로 리다이렉트시 토스트 메시지 분기와 로그인 성공시 원래 있던 곳으로 다시 보내는 로직을 구현하기 위해 url parameter와 sessionStorage를 사용했습니다. 
- AuthRequired 부분은 아직 리팩토링을 진행하지 않은 상태입니다.
- 토스트 코드가 너무 반복되어서 createToast 함수를 만들어서 재사용했습니다!

## 😡 Trouble Shooting

## 👀 스크린샷 / GIF / 링크

## 📚 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
