### PR TITLE
qa/#347: 모바일 카테고리 버튼 스크롤 해시 제거

### DIFF
--- a/components/blog/ui/CategoryBtnBar.tsx
+++ b/components/blog/ui/CategoryBtnBar.tsx
@@ -21,7 +21,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
     if (MOBILE)
       return (
         <MobileCategoryBtn
-          href={{ pathname: `/home/${eachCategory}`, hash: '/' }}
+          href={`/home/${eachCategory}`}
           key={eachCategory}
           className={eachCategory === decodeURI(category) ? 'selected' : ''}>
           {eachCategory}
@@ -41,7 +41,7 @@ const CategoryBtnBar = (props: CategoryBtnBarProps) => {
   if (MOBILE)
     return (
       <CategoryBtnBarContainer className="mobile">
-        <MobileCategoryBtn href={{ pathname: `/home`, hash: '/' }} className={SELECTED === 'home' ? 'selected' : ''}>
+        <MobileCategoryBtn href={`/home`} className={SELECTED === 'home' ? 'selected' : ''}>
           전체
         </MobileCategoryBtn>
         {CATEGORY_LIST}


### PR DESCRIPTION
## 🔥 Related Issues
- close #347 

## 💙 작업 내용
- [x] 모바일 뷰의 경우 카테고리 버튼 클릭 시 스크롤 탑이 되도록 href의 해시값을 제거해줬습니다

## ✅ PR Point
- 모바일의 경우 카테고리 바까지만 스크롤 되도록 넣어준 해시값을 제거해 화면 맨 위로 스크롤 되도록 수정했습니다