### PR TITLE
RELEASE v3.10.2 - 에디터 내부 이미지(base64, 외부 링크) 이슈 처리

### DIFF
--- a/api/postImage.ts
+++ b/api/postImage.ts
@@ -1,8 +1,20 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
+
+import client from '.';
 
 export const postImage = async (formData: FormData) => {
   const { data } = await axios.post(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v2/dashboard/image/add`, formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
+  return data;
+};
+
+export const postExternalImage = async (imageUrl: string) => {
+  const { data } = await client.post(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v2/dashboard/image/encode`, {
+    imageUrl,
+  });
+  if (data.code === 400) {
+    return null;
+  }
   return data;
 };

--- a/components/editor/TextEditor.tsx
+++ b/components/editor/TextEditor.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'next/navigation';
 import styled from 'styled-components';
 
 import { postExternalImage } from '@/api/postImage';
+import { getChangedImgSrc } from '@/utils/getChangedImgSrc';
 import { getContentCtrlVImage } from '@/utils/getImageMultipartData';
 
 interface editorProps {
@@ -42,26 +43,8 @@ const TextEditor = ({ editor, handleDragOver, handleDrop }: editorProps) => {
     const targetImg = event.currentTarget.querySelector(
       'img:not([src^="https://cdn.palms.blog/"]):not([class^="ProseMirror"]):not([class="inaccessible"]), img[class="ProseMirror-selectednode"]:not([src^="https://cdn.palms.blog/"]):not([class^="inaccessible"])',
     );
-    // src뽑아내기
-    let imgSrc = targetImg?.getAttribute('src');
-    if (!imgSrc) return;
-
-    // 외부 링크인 경우 base64로 받아내기
-    if (!imgSrc.startsWith('data:')) {
-      const data = await postExternalImage(imgSrc);
-      // 접근 권한이 없는 경우
-      if (!data) {
-        targetImg?.classList.add('inaccessible');
-        return;
-      }
-      imgSrc = `data:image/png;base64,${data}`;
-    }
-
-    // base64 -> File -> CDN 주소 받아오기
-    const blob = await fetch(imgSrc).then((res) => res.blob());
-    const file = new File([blob], 'image.png', { type: 'image/png' });
-    const imgUrl = await getContentCtrlVImage(file, String(team));
-    if (imgUrl) targetImg?.setAttribute('src', imgUrl);
+    if (!targetImg) return;
+    await getChangedImgSrc(targetImg, String(team));
   };
 
   return (

--- a/utils/editor/getEditorContent.ts
+++ b/utils/editor/getEditorContent.ts
@@ -1,15 +1,30 @@
+import { postExternalImage } from '@/api/postImage';
+
 import { getContentCtrlVImage } from '../getImageMultipartData';
 
 // 이미지 CDN 주소로 바꿔 끼우기 함수
 const changeImgSrc = async (team: string) => {
   const imgList = document.querySelectorAll(
-    'img:not([src^="https://cdn.palms.blog/"]):not([class="ProseMirror-separator"])',
+    'img:not([src^="https://cdn.palms.blog/"]):not([class="ProseMirror-separator"]):not([class="inaccessible"])',
   );
 
   const promises = Array.from(imgList).map(async (img) => {
-    const imgSrc = img.getAttribute('src');
+    // src뽑아내기
+    let imgSrc = img.getAttribute('src');
     if (!imgSrc) return;
 
+    // 외부 링크인 경우 base64로 받아내기
+    if (!imgSrc.startsWith('data:')) {
+      const data = await postExternalImage(imgSrc);
+      // 접근 권한이 없는 경우
+      if (!data) {
+        img?.classList.add('inaccessible');
+        return;
+      }
+      imgSrc = `data:image/png;base64,${data}`;
+    }
+
+    // base64 -> File -> CDN 주소 받아오기
     const blob = await fetch(imgSrc).then((res) => res.blob());
     const file = new File([blob], 'image.png', { type: 'image/png' });
     const imgUrl = await getContentCtrlVImage(file, String(team));

--- a/utils/editor/getEditorContent.ts
+++ b/utils/editor/getEditorContent.ts
@@ -1,6 +1,4 @@
-import { postExternalImage } from '@/api/postImage';
-
-import { getContentCtrlVImage } from '../getImageMultipartData';
+import { getChangedImgSrc } from '../getChangedImgSrc';
 
 // 이미지 CDN 주소로 바꿔 끼우기 함수
 const changeImgSrc = async (team: string) => {
@@ -9,27 +7,7 @@ const changeImgSrc = async (team: string) => {
   );
 
   const promises = Array.from(imgList).map(async (img) => {
-    // src뽑아내기
-    let imgSrc = img.getAttribute('src');
-    if (!imgSrc) return;
-
-    // 외부 링크인 경우 base64로 받아내기
-    if (!imgSrc.startsWith('data:')) {
-      const data = await postExternalImage(imgSrc);
-      // 접근 권한이 없는 경우
-      if (!data) {
-        img?.classList.add('inaccessible');
-        return;
-      }
-      imgSrc = `data:image/png;base64,${data}`;
-    }
-
-    // base64 -> File -> CDN 주소 받아오기
-    const blob = await fetch(imgSrc).then((res) => res.blob());
-    const file = new File([blob], 'image.png', { type: 'image/png' });
-    const imgUrl = await getContentCtrlVImage(file, String(team));
-    img.setAttribute('src', imgUrl);
-
+    const imgUrl = await getChangedImgSrc(img, String(team));
     return imgUrl;
   });
 

--- a/utils/getChangedImgSrc.ts
+++ b/utils/getChangedImgSrc.ts
@@ -1,0 +1,27 @@
+import { postExternalImage } from '@/api/postImage';
+
+import { getContentCtrlVImage } from './getImageMultipartData';
+
+export const getChangedImgSrc = async (img: Element, team: string): Promise<string | undefined> => {
+  // src뽑아내기
+  let imgSrc = img.getAttribute('src');
+  if (!imgSrc) return;
+
+  // 외부 링크인 경우 base64로 받아내기
+  if (!imgSrc.startsWith('data:')) {
+    const data = await postExternalImage(imgSrc);
+    // 접근 권한이 없는 경우
+    if (!data) {
+      img?.classList.add('inaccessible');
+      return;
+    }
+    imgSrc = `data:image/png;base64,${data}`;
+  }
+
+  // base64 -> File -> CDN 주소 받아오기
+  const blob = await fetch(imgSrc).then((res) => res.blob());
+  const file = new File([blob], 'image.png', { type: 'image/png' });
+  const imgUrl = await getContentCtrlVImage(file, String(team));
+  img.setAttribute('src', imgUrl);
+  return imgUrl;
+};


### PR DESCRIPTION
## 🔥 Related Issues
- close #478

## 💙 작업 내용
- [x] base64 이미지, 외부 링크 이미지 해결

## ✅ PR Point
1.`붙여넣기 할 때 마다 변경` + 2.`임시저장, 발행하기 할 때 아직 변경되지 않은 것들 일괄 변경`
_**두 방법을 모두 사용**_ 하도록 구현했습니다.

이외에 저번과 달라진 점이 있다면
외부 링크를 전달하면 백엔드에서 접근해서 base64로 바꿔 전달해주도록 중간에 API가 추가되었습니다.

⭐ 이 때 **서버에서도 접근이 거부당한 이미지의 경우 다시 변경을 시도하지 않도록 => class에 `inaccessible` 을 추가 처리**해놨습니다!
