### PR TITLE
Fix: 인증 메일 실패시 404 띄우기

### DIFF
--- a/api/user.ts
+++ b/api/user.ts
@@ -1,3 +1,5 @@
+import { isAxiosError } from 'axios';
+
 import { Response } from '@/types/common';
 import { DeleteRequestBody, InviteRequestBody, UserInfoProps, UserInviteInfo } from '@/types/user';
 
@@ -40,17 +42,13 @@ export const postMemberInvite = async (blogUrl: string, requestBody: InviteReque
 // 초대 조회하기
 export const getMemberInvite = async (code: string | null) => {
   if (!code) return;
-  const { data } = await client
-    .get<Response<UserInviteInfo>>(`/api/v2/dashboard/user/invite?code=${code}`)
-    .catch((e) => {
-      if (e.response.status === 403) {
-        return { message: null, code: 403, data: null };
-      } else if (e.response.status === 404) {
-        return { message: null, code: 404, data: null };
-      }
-      return { message: null, code: 400, data: null };
-    });
-  return data;
+  try {
+    const { data } = await client.get<Response<UserInviteInfo>>(`/api/v2/dashboard/user/invite?code=${code}`);
+    return data;
+  } catch (e) {
+    if (isAxiosError(e)) return { message: null, code: e.response?.status, data: null };
+    else return { message: null, code: 404, data: null };
+  }
 };
 
 // 초대 삭제하기

--- a/app/(auth)/login/password/reset/page.tsx
+++ b/app/(auth)/login/password/reset/page.tsx
@@ -13,7 +13,12 @@ const Page = () => {
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
 
-  if (!code) return <InviteNotFound type="reset" />;
+  if (!code)
+    return (
+      <Suspense>
+        <InviteNotFound type="reset" />
+      </Suspense>
+    );
 
   // 검증 미실행 된 경우에만 검증
   if (sessionStorage?.getItem('isVerify') !== 'true') {

--- a/app/(auth)/login/password/reset/page.tsx
+++ b/app/(auth)/login/password/reset/page.tsx
@@ -1,42 +1,14 @@
 'use client';
 import { Suspense } from 'react';
-import { useSearchParams } from 'next/navigation';
 
 import PasswordResetLanding from '@/components/auth/login/password/reset/PasswordResetLanding';
-import PasswordVerify from '@/components/auth/login/password/reset/PasswordVerify';
-import InviteNotFound from '@/components/invite/ui/InviteNotFound';
-import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
-const Page = () => {
-  const sessionStorage = checkSessionStorage();
-  // 이메일 인증 code(토큰) 받아오기
-  const searchParams = useSearchParams();
-  const code = searchParams.get('code');
-
-  if (!code)
-    return (
-      <Suspense>
-        <InviteNotFound type="reset" />
-      </Suspense>
-    );
-
-  // 검증 미실행 된 경우에만 검증
-  if (sessionStorage?.getItem('isVerify') !== 'true') {
-    // 토큰 검증
-    return (
-      <Suspense>
-        <PasswordVerify code={code} />{' '}
-      </Suspense>
-    );
-  } else {
-    // 비밀번호 재설정 UI 렌더링
-    const email = sessionStorage?.getItem('email');
-    return (
-      <Suspense>
-        <PasswordResetLanding emailData={email || 'you@example.com'} />
-      </Suspense>
-    );
-  }
+const page = () => {
+  return (
+    <Suspense>
+      <PasswordResetLanding />
+    </Suspense>
+  );
 };
 
-export default Page;
+export default page;

--- a/app/(auth)/login/password/reset/page.tsx
+++ b/app/(auth)/login/password/reset/page.tsx
@@ -18,7 +18,11 @@ const Page = () => {
   // 검증 미실행 된 경우에만 검증
   if (sessionStorage?.getItem('isVerify') !== 'true') {
     // 토큰 검증
-    return <PasswordVerify code={code} />;
+    return (
+      <Suspense>
+        <PasswordVerify code={code} />{' '}
+      </Suspense>
+    );
   } else {
     // 비밀번호 재설정 UI 렌더링
     const email = sessionStorage?.getItem('email');

--- a/app/(auth)/login/password/reset/page.tsx
+++ b/app/(auth)/login/password/reset/page.tsx
@@ -1,13 +1,28 @@
-import React, { Suspense } from 'react';
+'use client';
+import { useSearchParams } from 'next/navigation';
 
 import PasswordResetLanding from '@/components/auth/login/password/reset/PasswordResetLanding';
+import PasswordVerify from '@/components/auth/login/password/reset/PasswordVerify';
+import InviteNotFound from '@/components/invite/ui/InviteNotFound';
+import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
-const page = () => {
-  return (
-    <Suspense>
-      <PasswordResetLanding />
-    </Suspense>
-  );
+const Page = () => {
+  const sessionStorage = checkSessionStorage();
+  // 이메일 인증 code(토큰) 받아오기
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  if (!code) return <InviteNotFound type="reset" />;
+
+  // 검증 미실행 된 경우에만 검증
+  if (sessionStorage?.getItem('isVerify') !== 'true') {
+    // 토큰 검증
+    return <PasswordVerify code={code} />;
+  } else {
+    // 비밀번호 재설정 UI 렌더링
+    const email = sessionStorage?.getItem('email');
+    return <PasswordResetLanding emailData={email || 'you@example.com'} />;
+  }
 };
 
-export default page;
+export default Page;

--- a/app/(auth)/login/password/reset/page.tsx
+++ b/app/(auth)/login/password/reset/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 
 import PasswordResetLanding from '@/components/auth/login/password/reset/PasswordResetLanding';
@@ -21,7 +22,11 @@ const Page = () => {
   } else {
     // 비밀번호 재설정 UI 렌더링
     const email = sessionStorage?.getItem('email');
-    return <PasswordResetLanding emailData={email || 'you@example.com'} />;
+    return (
+      <Suspense>
+        <PasswordResetLanding emailData={email || 'you@example.com'} />
+      </Suspense>
+    );
   }
 };
 

--- a/components/auth/AuthRequired.tsx
+++ b/components/auth/AuthRequired.tsx
@@ -62,7 +62,18 @@ const AuthRequired = ({ children }: { children: React.ReactNode }) => {
       async (error) => {
         const { config } = error;
 
+        // 재시도 5회 제한
+        if (!config.__retryCount) {
+          config.__retryCount = 0;
+        }
+        if (config.__retryCount >= 5) {
+          return Promise.reject(error);
+        }
+
         if (!error.response) {
+          // 재시도 횟수 추가
+          config.__retryCount += 1;
+
           // 최초 reissue 요청이 있으므로, 해당 config 구독
           if (lock) {
             return new Promise((resolve) => {

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -8,15 +8,15 @@ import InviteNotFound from '@/components/invite/ui/InviteNotFound';
 import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
 const PasswordResetLanding = () => {
-  const [isVerify, setIsVerify] = useState(false);
+  const [isVerify, setIsVerify] = useState(true);
   // 이메일 인증 code(토큰) 받아오기
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
+  const sessionStorage = checkSessionStorage();
 
   useEffect(() => {
-    const sessionStorage = checkSessionStorage();
-    if (sessionStorage?.getItem('isVerify') === 'true') {
-      setIsVerify(true);
+    if (sessionStorage?.getItem('isVerify') !== 'true') {
+      setIsVerify(false);
     }
   }, []);
 

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -9,18 +9,27 @@ import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
 const PasswordResetLanding = () => {
   const [isVerify, setIsVerify] = useState(true);
+  const [isClient, setIsClient] = useState(false);
+  const [email, setEmail] = useState('');
+
   // 이메일 인증 code(토큰) 받아오기
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
-  const sessionStorage = checkSessionStorage();
 
   useEffect(() => {
+    setIsClient(true);
+
+    const sessionStorage = checkSessionStorage();
     if (sessionStorage?.getItem('isVerify') !== 'true') {
       setIsVerify(false);
     }
+
+    const emailData = sessionStorage?.getItem('email');
+    setEmail(emailData || 'you@example.com');
   }, []);
 
   if (!code) return <InviteNotFound type="reset" />;
+  if (!isClient) return null;
 
   // 검증 미실행 된 경우에만 검증
   if (!isVerify) {
@@ -28,8 +37,7 @@ const PasswordResetLanding = () => {
     return <PasswordVerify code={code} />;
   } else {
     // 비밀번호 재설정 UI 렌더링
-    const email = sessionStorage?.getItem('email');
-    return <PasswordResetUiLanding emailData={email || 'you@example.com'} />;
+    return <PasswordResetUiLanding emailData={email} />;
   }
 };
 

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
 import PasswordResetUiLanding from '@/components/auth/login/password/reset/PasswordResetUiLanding';
@@ -8,15 +8,22 @@ import InviteNotFound from '@/components/invite/ui/InviteNotFound';
 import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
 const PasswordResetLanding = () => {
-  const sessionStorage = checkSessionStorage();
+  const [isVerify, setIsVerify] = useState(false);
   // 이메일 인증 code(토큰) 받아오기
   const searchParams = useSearchParams();
   const code = searchParams.get('code');
 
+  useEffect(() => {
+    const sessionStorage = checkSessionStorage();
+    if (sessionStorage?.getItem('isVerify') === 'true') {
+      setIsVerify(true);
+    }
+  }, []);
+
   if (!code) return <InviteNotFound type="reset" />;
 
   // 검증 미실행 된 경우에만 검증
-  if (sessionStorage?.getItem('isVerify') !== 'true') {
+  if (!isVerify) {
     // 토큰 검증
     return <PasswordVerify code={code} />;
   } else {

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -1,104 +1,29 @@
 'use client';
-import React, { useEffect, useState } from 'react';
-import { Toaster } from 'react-hot-toast';
+import React from 'react';
+import { useSearchParams } from 'next/navigation';
 
-import { resetPassword } from '@/api/auth';
-import BgButton from '@/components/auth/ui/BgButton';
-import ConditionCheck from '@/components/auth/ui/ConditionCheck';
-import DisabledInput from '@/components/auth/ui/DisabledInput';
-import FlexContainer from '@/components/auth/ui/FlexContainer';
-import Input from '@/components/auth/ui/Input';
-import LinkButton from '@/components/auth/ui/LinkButton';
-import Title from '@/components/auth/ui/Title';
-import { capitalCheck, failResetPassword, numberCheck, specialCharCheck, successResetPassword } from '@/utils/auth';
+import PasswordResetUiLanding from '@/components/auth/login/password/reset/PasswordResetUiLanding';
+import PasswordVerify from '@/components/auth/login/password/reset/PasswordVerify';
+import InviteNotFound from '@/components/invite/ui/InviteNotFound';
+import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
-interface PasswordResetLandingProps {
-  emailData: string;
-}
+const PasswordResetLanding = () => {
+  const sessionStorage = checkSessionStorage();
+  // 이메일 인증 code(토큰) 받아오기
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
 
-const PasswordResetLanding = (props: PasswordResetLandingProps) => {
-  const { emailData } = props;
+  if (!code) return <InviteNotFound type="reset" />;
 
-  const [{ email, password, passwordCheck }, setValue] = useState({
-    email: sessionStorage?.getItem('email') || '',
-    password: '',
-    passwordCheck: '',
-  });
-
-  useEffect(() => {
-    setValue((prev) => ({ ...prev, email: emailData }));
-  }, []);
-
-  const handleResetPassword = async () => {
-    // 비밀번호 재설정 API 호출
-    const data = await resetPassword({ email, password });
-    if (!data) return;
-
-    // 성공시
-    if (data.code === 200) {
-      successResetPassword();
-      sessionStorage?.removeItem('isVerify');
-      sessionStorage?.removeItem('email');
-    }
-    // 실패시
-    else {
-      failResetPassword();
-    }
-  };
-
-  return (
-    <>
-      <Toaster
-        position="top-right"
-        reverseOrder={false}
-        containerClassName=""
-        containerStyle={{
-          top: 20,
-          right: 24,
-        }}
-      />
-      <FlexContainer margin={'12rem 0'}>
-        <Title>비밀번호 재설정</Title>
-
-        <DisabledInput value={email || ''}>이메일</DisabledInput>
-
-        <Input
-          value={password}
-          setValue={(newValue: string) => setValue((prev) => ({ ...prev, password: newValue }))}
-          type="password">
-          새로운 비밀번호
-        </Input>
-        <Input
-          value={passwordCheck}
-          setValue={(newValue: string) => setValue((prev) => ({ ...prev, passwordCheck: newValue }))}
-          type="password">
-          새로운 비밀번호 확인
-        </Input>
-
-        <ConditionCheck isSatisfied={capitalCheck(password)}>대문자 1자 이상</ConditionCheck>
-        <ConditionCheck isSatisfied={numberCheck(password)}>숫자 1자 이상</ConditionCheck>
-        <ConditionCheck isSatisfied={specialCharCheck(password)}>특수문자 1자 이상</ConditionCheck>
-        <ConditionCheck isSatisfied={password.length >= 8}>전체 8자 이상</ConditionCheck>
-        <ConditionCheck isSatisfied={password === passwordCheck && password !== ''}>비밀번호 확인 일치</ConditionCheck>
-
-        <BgButton
-          disabled={
-            !(
-              capitalCheck(password) &&
-              numberCheck(password) &&
-              specialCharCheck(password) &&
-              password.length >= 8 &&
-              password === passwordCheck &&
-              password !== ''
-            )
-          }
-          onClick={handleResetPassword}>
-          비밀번호 재설정
-        </BgButton>
-        <LinkButton href="/login">로그인</LinkButton>
-      </FlexContainer>
-    </>
-  );
+  // 검증 미실행 된 경우에만 검증
+  if (sessionStorage?.getItem('isVerify') !== 'true') {
+    // 토큰 검증
+    return <PasswordVerify code={code} />;
+  } else {
+    // 비밀번호 재설정 UI 렌더링
+    const email = sessionStorage?.getItem('email');
+    return <PasswordResetUiLanding emailData={email || 'you@example.com'} />;
+  }
 };
 
 export default PasswordResetLanding;

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -8,7 +8,7 @@ import InviteNotFound from '@/components/invite/ui/InviteNotFound';
 import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
 const PasswordResetLanding = () => {
-  const [isVerify, setIsVerify] = useState(true);
+  const [isVerify, setIsVerify] = useState(false);
   const [isClient, setIsClient] = useState(false);
   const [email, setEmail] = useState('');
 
@@ -20,8 +20,8 @@ const PasswordResetLanding = () => {
     setIsClient(true);
 
     const sessionStorage = checkSessionStorage();
-    if (sessionStorage?.getItem('isVerify') !== 'true') {
-      setIsVerify(false);
+    if (sessionStorage?.getItem('isVerify') === 'true') {
+      setIsVerify(true);
     }
 
     const emailData = sessionStorage?.getItem('email');

--- a/components/auth/login/password/reset/PasswordResetLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetLanding.tsx
@@ -1,9 +1,8 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
-import { useSearchParams } from 'next/navigation';
 
-import { getVerifyEmail, resetPassword } from '@/api/auth';
+import { resetPassword } from '@/api/auth';
 import BgButton from '@/components/auth/ui/BgButton';
 import ConditionCheck from '@/components/auth/ui/ConditionCheck';
 import DisabledInput from '@/components/auth/ui/DisabledInput';
@@ -11,13 +10,14 @@ import FlexContainer from '@/components/auth/ui/FlexContainer';
 import Input from '@/components/auth/ui/Input';
 import LinkButton from '@/components/auth/ui/LinkButton';
 import Title from '@/components/auth/ui/Title';
-import InviteNotFound from '@/components/invite/ui/InviteNotFound';
 import { capitalCheck, failResetPassword, numberCheck, specialCharCheck, successResetPassword } from '@/utils/auth';
-import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
-const PasswordResetLanding = () => {
-  const sessionStorage = checkSessionStorage();
-  const [isDisabled, setIsDisabled] = useState(false);
+interface PasswordResetLandingProps {
+  emailData: string;
+}
+
+const PasswordResetLanding = (props: PasswordResetLandingProps) => {
+  const { emailData } = props;
 
   const [{ email, password, passwordCheck }, setValue] = useState({
     email: sessionStorage?.getItem('email') || '',
@@ -25,33 +25,8 @@ const PasswordResetLanding = () => {
     passwordCheck: '',
   });
 
-  const searchParams = useSearchParams();
-  const code = searchParams.get('code');
-
   useEffect(() => {
-    // 새로고침시 검증 미실행 여부 & 비밀번호 재설정 미완료 여부 확인 후 실행
-    if (sessionStorage?.getItem('isVerify') !== 'true' && isDisabled === false) {
-      const verifyEmail = async () => {
-        if (code) {
-          // 이메일 인증 API 호출
-          const data = await getVerifyEmail('reset', code);
-          if (!data) return;
-          // 실패시
-          if (data.code !== 200) {
-            return <InviteNotFound type="reset" />;
-          }
-          // 성공시
-          else {
-            if (data.data) {
-              setValue((prev) => ({ ...prev, email: data.data?.email }));
-              sessionStorage?.setItem('email', data.data.email);
-              sessionStorage?.setItem('isVerify', 'true');
-            }
-          }
-        }
-      };
-      verifyEmail();
-    }
+    setValue((prev) => ({ ...prev, email: emailData }));
   }, []);
 
   const handleResetPassword = async () => {
@@ -64,7 +39,6 @@ const PasswordResetLanding = () => {
       successResetPassword();
       sessionStorage?.removeItem('isVerify');
       sessionStorage?.removeItem('email');
-      setIsDisabled(true);
     }
     // 실패시
     else {
@@ -87,27 +61,19 @@ const PasswordResetLanding = () => {
         <Title>비밀번호 재설정</Title>
 
         <DisabledInput value={email || ''}>이메일</DisabledInput>
-        {isDisabled ? (
-          <>
-            <DisabledInput value={password}>새로운 비밀번호</DisabledInput>
-            <DisabledInput value={password}>새로운 비밀번호 확인</DisabledInput>
-          </>
-        ) : (
-          <>
-            <Input
-              value={password}
-              setValue={(newValue: string) => setValue((prev) => ({ ...prev, password: newValue }))}
-              type="password">
-              새로운 비밀번호
-            </Input>
-            <Input
-              value={passwordCheck}
-              setValue={(newValue: string) => setValue((prev) => ({ ...prev, passwordCheck: newValue }))}
-              type="password">
-              새로운 비밀번호 확인
-            </Input>
-          </>
-        )}
+
+        <Input
+          value={password}
+          setValue={(newValue: string) => setValue((prev) => ({ ...prev, password: newValue }))}
+          type="password">
+          새로운 비밀번호
+        </Input>
+        <Input
+          value={passwordCheck}
+          setValue={(newValue: string) => setValue((prev) => ({ ...prev, passwordCheck: newValue }))}
+          type="password">
+          새로운 비밀번호 확인
+        </Input>
 
         <ConditionCheck isSatisfied={capitalCheck(password)}>대문자 1자 이상</ConditionCheck>
         <ConditionCheck isSatisfied={numberCheck(password)}>숫자 1자 이상</ConditionCheck>

--- a/components/auth/login/password/reset/PasswordResetUiLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetUiLanding.tsx
@@ -46,10 +46,6 @@ const PasswordResetUiLanding = (props: PasswordResetUiLandingProps) => {
       sessionStorage?.removeItem('isVerify');
       sessionStorage?.removeItem('email');
       setIsDisabled(true);
-
-      setTimeout(() => {
-        router.push('/login');
-      }, 3200);
     }
     // 실패시
     else {

--- a/components/auth/login/password/reset/PasswordResetUiLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetUiLanding.tsx
@@ -1,0 +1,124 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { Toaster } from 'react-hot-toast';
+import { useRouter } from 'next/navigation';
+
+import { resetPassword } from '@/api/auth';
+import BgButton from '@/components/auth/ui/BgButton';
+import ConditionCheck from '@/components/auth/ui/ConditionCheck';
+import DisabledInput from '@/components/auth/ui/DisabledInput';
+import FlexContainer from '@/components/auth/ui/FlexContainer';
+import Input from '@/components/auth/ui/Input';
+import LinkButton from '@/components/auth/ui/LinkButton';
+import Title from '@/components/auth/ui/Title';
+import { capitalCheck, failResetPassword, numberCheck, specialCharCheck, successResetPassword } from '@/utils/auth';
+import { checkSessionStorage } from '@/utils/checkSessionStorage';
+
+interface PasswordResetUiLandingProps {
+  emailData: string;
+}
+
+const PasswordResetUiLanding = (props: PasswordResetUiLandingProps) => {
+  const { emailData } = props;
+  const router = useRouter();
+  const sessionStorage = checkSessionStorage();
+
+  const [isDisabled, setIsDisabled] = useState(false);
+
+  const [{ email, password, passwordCheck }, setValue] = useState({
+    email: sessionStorage?.getItem('email') || '',
+    password: '',
+    passwordCheck: '',
+  });
+
+  useEffect(() => {
+    setValue((prev) => ({ ...prev, email: emailData }));
+  }, []);
+
+  const handleResetPassword = async () => {
+    // 비밀번호 재설정 API 호출
+    const data = await resetPassword({ email, password });
+    if (!data) return;
+
+    // 성공시
+    if (data.code === 200) {
+      successResetPassword();
+      sessionStorage?.removeItem('isVerify');
+      sessionStorage?.removeItem('email');
+      setIsDisabled(true);
+
+      setTimeout(() => {
+        router.push('/login');
+      }, 3200);
+    }
+    // 실패시
+    else {
+      failResetPassword();
+    }
+  };
+
+  return (
+    <>
+      <Toaster
+        position="top-right"
+        reverseOrder={false}
+        containerClassName=""
+        containerStyle={{
+          top: 20,
+          right: 24,
+        }}
+      />
+      <FlexContainer margin={'12rem 0'}>
+        <Title>비밀번호 재설정</Title>
+
+        <DisabledInput value={email || ''}>이메일</DisabledInput>
+        {isDisabled ? (
+          <>
+            <DisabledInput value={password || '••••••••'}>새로운 비밀번호</DisabledInput>{' '}
+            <DisabledInput value={password || '••••••••'}>새로운 비밀번호 확인</DisabledInput>
+          </>
+        ) : (
+          <>
+            {' '}
+            <Input
+              value={password}
+              setValue={(newValue: string) => setValue((prev) => ({ ...prev, password: newValue }))}
+              type="password">
+              새로운 비밀번호
+            </Input>
+            <Input
+              value={passwordCheck}
+              setValue={(newValue: string) => setValue((prev) => ({ ...prev, passwordCheck: newValue }))}
+              type="password">
+              새로운 비밀번호 확인
+            </Input>
+          </>
+        )}
+
+        <ConditionCheck isSatisfied={capitalCheck(password)}>대문자 1자 이상</ConditionCheck>
+        <ConditionCheck isSatisfied={numberCheck(password)}>숫자 1자 이상</ConditionCheck>
+        <ConditionCheck isSatisfied={specialCharCheck(password)}>특수문자 1자 이상</ConditionCheck>
+        <ConditionCheck isSatisfied={password.length >= 8}>전체 8자 이상</ConditionCheck>
+        <ConditionCheck isSatisfied={password === passwordCheck && password !== ''}>비밀번호 확인 일치</ConditionCheck>
+
+        <BgButton
+          disabled={
+            !(
+              capitalCheck(password) &&
+              numberCheck(password) &&
+              specialCharCheck(password) &&
+              password.length >= 8 &&
+              password === passwordCheck &&
+              password !== ''
+            )
+          }
+          onClick={handleResetPassword}>
+          비밀번호 재설정
+        </BgButton>
+        <LinkButton href="/login">로그인</LinkButton>
+      </FlexContainer>
+    </>
+  );
+};
+
+export default PasswordResetUiLanding;

--- a/components/auth/login/password/reset/PasswordResetUiLanding.tsx
+++ b/components/auth/login/password/reset/PasswordResetUiLanding.tsx
@@ -1,7 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
-import { useRouter } from 'next/navigation';
 
 import { resetPassword } from '@/api/auth';
 import BgButton from '@/components/auth/ui/BgButton';
@@ -20,13 +19,12 @@ interface PasswordResetUiLandingProps {
 
 const PasswordResetUiLanding = (props: PasswordResetUiLandingProps) => {
   const { emailData } = props;
-  const router = useRouter();
   const sessionStorage = checkSessionStorage();
 
   const [isDisabled, setIsDisabled] = useState(false);
 
   const [{ email, password, passwordCheck }, setValue] = useState({
-    email: sessionStorage?.getItem('email') || '',
+    email: emailData,
     password: '',
     passwordCheck: '',
   });

--- a/components/auth/login/password/reset/PasswordVerify.tsx
+++ b/components/auth/login/password/reset/PasswordVerify.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+import InviteNotFound from '@/components/invite/ui/InviteNotFound';
+import { useGetVerifyEmail } from '@/hooks/auth';
+import { checkSessionStorage } from '@/utils/checkSessionStorage';
+
+import PasswordResetLanding from './PasswordResetLanding';
+
+const PasswordVerify = ({ code }: { code: string }) => {
+  const sessionStorage = checkSessionStorage();
+
+  // 토큰 검증
+  const data = useGetVerifyEmail('reset', code);
+
+  // 실패시
+  if (!data || !data.data || data.code !== 200) {
+    return <InviteNotFound type="reset" />;
+  }
+
+  // 성공시
+  sessionStorage?.setItem('email', data.data.email);
+  sessionStorage?.setItem('isVerify', 'true');
+  return <PasswordResetLanding emailData={data.data.email} />;
+};
+
+export default PasswordVerify;

--- a/components/auth/login/password/reset/PasswordVerify.tsx
+++ b/components/auth/login/password/reset/PasswordVerify.tsx
@@ -8,10 +8,12 @@ import { checkSessionStorage } from '@/utils/checkSessionStorage';
 import PasswordResetUiLanding from './PasswordResetUiLanding';
 
 const PasswordVerify = ({ code }: { code: string }) => {
-  const sessionStorage = checkSessionStorage();
-
   // 토큰 검증
   const data = useGetVerifyEmail('reset', code);
+
+  const sessionStorage = checkSessionStorage();
+  if (sessionStorage?.getItem('isVerify') === 'true')
+    return <PasswordResetUiLanding emailData={sessionStorage?.getItem('email') || ''} />;
 
   if (!data) return;
 

--- a/components/auth/login/password/reset/PasswordVerify.tsx
+++ b/components/auth/login/password/reset/PasswordVerify.tsx
@@ -5,7 +5,7 @@ import InviteNotFound from '@/components/invite/ui/InviteNotFound';
 import { useGetVerifyEmail } from '@/hooks/auth';
 import { checkSessionStorage } from '@/utils/checkSessionStorage';
 
-import PasswordResetLanding from './PasswordResetLanding';
+import PasswordResetUiLanding from './PasswordResetUiLanding';
 
 const PasswordVerify = ({ code }: { code: string }) => {
   const sessionStorage = checkSessionStorage();
@@ -13,15 +13,17 @@ const PasswordVerify = ({ code }: { code: string }) => {
   // 토큰 검증
   const data = useGetVerifyEmail('reset', code);
 
+  if (!data) return;
+
   // 실패시
-  if (!data || !data.data || data.code !== 200) {
+  if (!data.data || data.code !== 200) {
     return <InviteNotFound type="reset" />;
   }
 
   // 성공시
   sessionStorage?.setItem('email', data.data.email);
   sessionStorage?.setItem('isVerify', 'true');
-  return <PasswordResetLanding emailData={data.data.email} />;
+  return <PasswordResetUiLanding emailData={data.data.email} />;
 };
 
 export default PasswordVerify;

--- a/components/invite/InviteLanding.tsx
+++ b/components/invite/InviteLanding.tsx
@@ -33,7 +33,7 @@ const InviteAcceptLanding = () => {
       router.push(`/login?userState=${LoginUserState.INVITE_MISMATCH}`);
     }
     // 유효하지 않은 초대 링크
-    else if (data.code === 404) {
+    else if (!data.data || data.code !== 200) {
       return <InviteNotFound type="invite" />;
     }
     // 초대 수락하기 폼

--- a/hooks/auth.ts
+++ b/hooks/auth.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { getAccessToken } from '@/api/auth';
+import { getAccessToken, getVerifyEmail } from '@/api/auth';
 import { deleteInvite, getMemberInvite, postMemberInvite } from '@/api/user';
 import { getAccessTokenProps } from '@/types/auth';
 import { DeleteRequestBody, InviteRequestBody } from '@/types/user';
@@ -10,6 +10,7 @@ import { QUERY_KEY_DASHBOARD } from './dashboard';
 const QUERY_KEY_AUTH = {
   auth: 'auth',
   invite: 'invite',
+  verify: 'verify',
 };
 
 export const useGetAccessToken = (props: getAccessTokenProps) => {
@@ -39,4 +40,9 @@ export const useDeleteInvite = (blogUrl: string, requestBody: DeleteRequestBody)
       queryClient.invalidateQueries([QUERY_KEY_DASHBOARD.getMemberInfo]);
     },
   });
+};
+
+export const useGetVerifyEmail = (type: string, code: string) => {
+  const { data } = useQuery([QUERY_KEY_AUTH.verify, type, code], () => getVerifyEmail(type, code));
+  return data;
 };


### PR DESCRIPTION
## 🔥 Related Issues
- close #498

## 💙 작업 내용
- [x] invite, 비밀번호 재설정 인증 메일 등 검증 응답이 200 아니면 404 페이지 뜨도록
- [x] interceptor 재시도 횟수 5회 제한
- [x] useSearchParams Suspense로 감싸기
- [x] hydration 해결
- [x] 비밀번호 재설정 성공시 처리 마지막 확인

## ✅ PR Point
* invite, 비밀번호 재설정 인증 메일 검증시 404 페이지가 제대로 잘 안 떠서 문제 수정했습니다.
* 모든 곳에서 reissue 무한 반복 호출을 막고자, interceptor 재시도 횟수 5회 제한 걸었습니다!
* 로직은 성공해도, hydration 문제가 남아 있어서 해결했습니당!


## 😡 해결하지 못한 점 (Optional)
- 

## 📚 Reference (Optional)
- 
