### PR TITLE
fix/#531: 페이지 임시저장, 발행하기 코드 수정

### DIFF
--- a/app/[team]/editor/page/[pageId]/publish/page.tsx
+++ b/app/[team]/editor/page/[pageId]/publish/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import AuthRequired from '@/components/auth/AuthRequired';
+import CategorySelect from '@/components/editor/publish/ui/CategorySelect';
+import OneLiner from '@/components/editor/publish/ui/OneLiner';
+import PublishBottomButtons from '@/components/editor/publish/ui/PublishBottom';
+import PublishTitle from '@/components/editor/publish/ui/PublishTitle';
+import ThumbnailInput from '@/components/editor/publish/ui/ThumbnailInput';
+import UrlCustom from '@/components/editor/publish/ui/UrlCustom';
+
+const PageDraftPublishPage = () => {
+  const [isDuplicate, setIsDuplicate] = useState<boolean | null>(false);
+  const [isAddressRulePassed, setIsAddressRulePassed] = useState<boolean>(true);
+
+  return (
+    <AuthRequired>
+      <PublishContainer>
+        <ArticlePublishContainer>
+          <ThumbnailInput pageType="page" />
+          <PublishTitle pageType="page" />
+          <CategorySelect />
+          <OneLiner />
+          <UrlCustom
+            pageType="page"
+            isDuplicate={isDuplicate}
+            setIsDuplicate={setIsDuplicate}
+            isAddressRulePassed={isAddressRulePassed}
+            setIsAddressRulePassed={setIsAddressRulePassed}
+          />
+          <PublishBottomButtons
+            pageType="page"
+            isDuplicate={isDuplicate}
+            isAddressRulePassed={isAddressRulePassed}
+            currentState="draft"
+          />
+        </ArticlePublishContainer>
+      </PublishContainer>
+    </AuthRequired>
+  );
+};
+
+export default PageDraftPublishPage;
+
+const PublishContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* width: 100vw; */
+`;
+
+const ArticlePublishContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8.1rem 45rem;
+  width: 54rem;
+  /* height: 100vh; */
+`;

--- a/components/editor/TextEditorImport.tsx
+++ b/components/editor/TextEditorImport.tsx
@@ -402,6 +402,7 @@ const TextEditorImport = (props: TextEditorImportProps) => {
           const pageId = res.data;
           if (pageId) {
             sessionStorage?.setItem(PAGE_DATA_ID, pageId);
+            setIsDraftSave(true);
           }
         } catch (error) {
           console.error('실패 에러임', error);
@@ -622,12 +623,15 @@ const TextEditorImport = (props: TextEditorImportProps) => {
   const handleOnSavedPagePublish = async () => {
     if (isDraftSave) {
       const dataPageId = sessionStorage?.getItem(PAGE_DATA_ID);
+      console.log(dataPageId);
       if (!editor) return;
       const { content, newImgArr } = await getEditorContent(String(team));
       setImageArr((prev) => [...prev, ...newImgArr]);
-      updateDataRouterChange(content, Number(dataPageId), `page/publish`);
+      updateDataRouterChange(content, Number(dataPageId), `page/${dataPageId}/publish`);
+      console.log('여기여기여기');
     } else {
       handleOnClickPagePublish();
+      console.log('여기면 안돼 찌바ㅠ');
     }
   };
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #531

## 💙 작업 내용
- [x] 페이지 임시저장, 발행하기 코드 수정
- [x] 캘린더 색상 변경

## ✅ PR Point
- 페이지 임시저장 하고 발행했는데, 발행한 페이지가 있는 상태에서 임시저장이 안 지워짐 해결
- 캘린더 선택 색상 변경했습니다
<변경 전>
<img width="592" alt="스크린샷 2024-07-21 오후 7 22 34" src="https://github.com/user-attachments/assets/f9b304fd-8c53-4591-b333-823f2a8e2f8a">
<변경 후>
<img width="592" alt="스크린샷 2024-07-21 오후 7 22 20" src="https://github.com/user-attachments/assets/faba7855-f725-4220-8de2-8534c97e7088">


https://github.com/user-attachments/assets/b2afa66a-f000-4d26-8b5a-d045f1595e17




