### PR TITLE
feat/#534:네비게이션, 페이지 상세설명 문구 추가

### DIFF
--- a/components/dashboard/components/DashBoardHeader.tsx
+++ b/components/dashboard/components/DashBoardHeader.tsx
@@ -24,7 +24,7 @@ const DashBoardHeader = () => {
 
   const { team } = useParams();
 
-  const { title, buttonInnerText, onButtonClickActionName } = mapPageType2HeaderInfo[pathName];
+  const { title, explanation, buttonInnerText, onButtonClickActionName } = mapPageType2HeaderInfo[pathName];
 
   const permissionPolicyChecker = usePerMissionPolicy();
 
@@ -62,6 +62,7 @@ const DashBoardHeader = () => {
     <DashBoardHeaderContainer>
       <HeaderContainer
         title={title}
+        explanation={explanation}
         buttonInnerText={buttonInnerText}
         isRenderHeaderButton={isRenderHeaderButton}
         onButtonClick={handleHeaderButtonClickEvent}

--- a/components/dashboard/components/ui/HeaderContainer.tsx
+++ b/components/dashboard/components/ui/HeaderContainer.tsx
@@ -6,6 +6,7 @@ import { dashBoardHeaderButtonVisibleState } from '../../state/modalState';
 
 interface UploadHeaderContainerProps {
   title: string;
+  explanation?: string;
   isRenderHeaderButton?: boolean;
   buttonInnerText?: string;
   onButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
@@ -20,14 +21,17 @@ interface UploadHeaderContainerProps {
  * @returns
  */
 const HeaderContainer = (props: UploadHeaderContainerProps) => {
-  const { title, buttonInnerText, onButtonClick, isRenderHeaderButton = true } = props;
+  const { title, explanation, buttonInnerText, onButtonClick, isRenderHeaderButton = true } = props;
 
   const headerButtonState = useRecoilValue(dashBoardHeaderButtonVisibleState);
 
   return (
     <UploadHeaderUI>
       <HeaderContentWrapper>
-        <span>{title}</span>
+        <TitleContainer>
+          <span>{title}</span>
+          <Explanation>{explanation}</Explanation>
+        </TitleContainer>
         {isRenderHeaderButton && buttonInnerText && headerButtonState && (
           <button onClick={onButtonClick}>{buttonInnerText}</button>
         )}
@@ -37,6 +41,23 @@ const HeaderContainer = (props: UploadHeaderContainerProps) => {
 };
 
 export default HeaderContainer;
+
+const TitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  & > span {
+    margin-right: 1.4rem;
+    ${({ theme }) => theme.fonts.Heading1};
+    color: ${({ theme }) => theme.colors.grey_950};
+  }
+`;
+
+const Explanation = styled.p`
+  margin-top: 1.4rem;
+  ${({ theme }) => theme.fonts.Body3_Regular};
+  color: ${({ theme }) => theme.colors.grey_900};
+`;
 
 const UploadHeaderUI = styled.article`
   display: flex;
@@ -54,10 +75,6 @@ const HeaderContentWrapper = styled.div`
   margin-bottom: 3.2rem;
   width: 100%;
 
-  & > span {
-    ${({ theme }) => theme.fonts.Heading1};
-    color: ${({ theme }) => theme.colors.grey_950};
-  }
   & > button {
     display: inline-flex;
     flex-shrink: 0;

--- a/components/statistics/BlogStatistics/VisitantCard.tsx
+++ b/components/statistics/BlogStatistics/VisitantCard.tsx
@@ -124,7 +124,7 @@ const CardBorder = styled.li`
   border: 1px solid ${({ theme }) => theme.colors.grey_300};
   border-radius: 0.8rem;
   background: var(--grey-white, #fff);
-  padding: 2rem 14rem 2rem 2rem;
+  padding: 2rem 0rem 2rem 2rem;
   list-style-type: none;
 `;
 

--- a/components/statistics/BlogStatistics/VistantChart.tsx
+++ b/components/statistics/BlogStatistics/VistantChart.tsx
@@ -64,24 +64,22 @@ const VisitantChart = (props: ChartProps) => {
         <CardBorder>
           <CalendarButton>
             <SubTitle>방문 수</SubTitle>
-            <CalendarWrapper>
-              <div onClick={openModal} ref={calendarRef}>
-                <CalendarIcon />
-                <ArrowCalendarIcon />
-              </div>
-              {isOpen && (
-                <ModalOverlay onClick={closeModal}>
-                  <CalendarContainer
-                    onClick={(e) => e.stopPropagation()}
-                    style={{
-                      top: `${calendarRef.current.getBoundingClientRect().bottom - 140}px`,
-                      left: `${calendarRef.current.getBoundingClientRect().left - 350}px`,
-                    }}>
-                    <Calendar setIsOpen={setIsOpen} />
-                  </CalendarContainer>
-                </ModalOverlay>
-              )}
+            <CalendarWrapper onClick={openModal} ref={calendarRef}>
+              <CalendarIcon />
+              <ArrowCalendarIcon />
             </CalendarWrapper>
+            {isOpen && (
+              <ModalOverlay onClick={closeModal}>
+                <CalendarContainer
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    top: `${calendarRef.current.getBoundingClientRect().bottom - 140}px`,
+                    left: `${calendarRef.current.getBoundingClientRect().left - 350}px`,
+                  }}>
+                  <Calendar setIsOpen={setIsOpen} />
+                </CalendarContainer>
+              </ModalOverlay>
+            )}
           </CalendarButton>
           <PercentContainer>
             <Count>{views}</Count>
@@ -145,6 +143,7 @@ const CalendarWrapper = styled.div`
   margin-right: 4rem;
   border: 1px solid ${({ theme }) => theme.colors.grey_400};
   border-radius: 0.4rem;
+  cursor: pointer;
   padding: 0.5rem 0.8rem;
 `;
 

--- a/components/statistics/common/Calendar.tsx
+++ b/components/statistics/common/Calendar.tsx
@@ -258,7 +258,7 @@ const Day = styled.div<DayProps>`
   justify-content: center;
   background-color: ${({ isSelected, isEndSelected, isInRange, theme }) => {
     if (isSelected || isEndSelected) return theme.colors.grey_900;
-    if (isInRange) return theme.colors.grey_100;
+    if (isInRange) return theme.colors.grey_300;
     return 'transparent';
   }};
   cursor: pointer;

--- a/constants/mapPageType2HeaderInfo.ts
+++ b/constants/mapPageType2HeaderInfo.ts
@@ -3,6 +3,7 @@ import { dashBoardPageType } from '@/types/dashboard';
 type mapPageType2HeaderInfoBluePrint = {
   [pageType in dashBoardPageType]: {
     title: string;
+    explanation?: string;
     buttonInnerText?: string;
     onButtonClickActionName?: modalStateProps;
   };
@@ -24,6 +25,8 @@ const mapPageType2HeaderInfo: mapPageType2HeaderInfoBluePrint = {
   },
   page: {
     title: '페이지',
+    explanation:
+      '아티클과 달리 작성일/작성자가 노출되지 않는 콘텐츠입니다. 회사 및 블로그 소개글 등의 용도로 활용할 수 있습니다.',
     buttonInnerText: '새 페이지 만들기',
     onButtonClickActionName: 'createPage', // 나중에 api 나오면 수정하기
   },
@@ -34,6 +37,8 @@ const mapPageType2HeaderInfo: mapPageType2HeaderInfoBluePrint = {
   },
   nav: {
     title: '네비게이션',
+    explanation:
+      '블로그 헤더에서 특정 페이지로의 이동을 위한 링크의 기능을 합니다. 페이지 또는 외부 웹사이트를 연결할 수 있습니다.',
     buttonInnerText: '새 네비게이션 만들기',
     onButtonClickActionName: 'createNavigation', // 나중에 api 나오면 수정하기
   },


### PR DESCRIPTION
## 🔥 Related Issues
- close #534 

## 💙 작업 내용
- [x] 네비게이션, 페이지 상세설명 문구 추가

## ✅ PR Point
네비게이션, 페이지 상세설명 문구 추가했습니다!
- 기존 props를 최대한 깨지않고 스타일만 수정할 수 있도록 코드 변경했습니다!

<img width="1440" alt="스크린샷 2024-07-23 오후 12 06 06" src="https://github.com/user-attachments/assets/57e5e5d7-a025-48ec-9ffa-c14a8e25a7a8">
<img width="1440" alt="스크린샷 2024-07-23 오후 12 06 11" src="https://github.com/user-attachments/assets/ceba582f-c67f-4413-948a-2934db3c84be">
